### PR TITLE
fix: resolve Vercel build crash and HTML hydration warning

### DIFF
--- a/app/api/watchlist/add/route.ts
+++ b/app/api/watchlist/add/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { supabaseAdmin, getAuthUser } from "@/lib/supabase-server";
+import { getSupabaseAdmin, getAuthUser } from "@/lib/supabase-server";
 
 // POST /api/watchlist/add
 // Saves a film to the user's watchlist.
@@ -29,7 +29,7 @@ export async function POST(request: NextRequest) {
   }
 
   // Check if this film is already in the user's watchlist
-  const { data: existing } = await supabaseAdmin
+  const { data: existing } = await getSupabaseAdmin()
     .from("watchlists")
     .select("id")
     .eq("user_id", user.id)
@@ -44,7 +44,7 @@ export async function POST(request: NextRequest) {
   }
 
   // Insert the new watchlist entry
-  const { data, error } = await supabaseAdmin
+  const { data, error } = await getSupabaseAdmin()
     .from("watchlists")
     .insert({
       user_id: user.id,

--- a/app/api/watchlist/remove/route.ts
+++ b/app/api/watchlist/remove/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { supabaseAdmin, getAuthUser } from "@/lib/supabase-server";
+import { getSupabaseAdmin, getAuthUser } from "@/lib/supabase-server";
 
 // DELETE /api/watchlist/remove
 // Removes a film from the user's watchlist.
@@ -21,7 +21,7 @@ export async function DELETE(request: NextRequest) {
   }
 
   // Delete only the row matching this user + this movie
-  const { error } = await supabaseAdmin
+  const { error } = await getSupabaseAdmin()
     .from("watchlists")
     .delete()
     .eq("user_id", user.id)

--- a/app/api/watchlist/route.ts
+++ b/app/api/watchlist/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { supabaseAdmin, getAuthUser } from "@/lib/supabase-server";
+import { getSupabaseAdmin, getAuthUser } from "@/lib/supabase-server";
 
 // GET /api/watchlist
 // Returns all saved films for the logged-in user, newest first.
@@ -11,7 +11,7 @@ export async function GET(request: NextRequest) {
   }
 
   // Step 2: Query the watchlists table — only rows belonging to this user
-  const { data, error } = await supabaseAdmin
+  const { data, error } = await getSupabaseAdmin()
     .from("watchlists")
     .select("*")
     .eq("user_id", user.id)

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -28,7 +28,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" data-theme="dark" className={`${lora.variable} ${jakarta.variable}`}>
+    <html lang="en" data-theme="dark" suppressHydrationWarning className={`${lora.variable} ${jakarta.variable}`}>
       <head>
         {/* Apply saved theme before paint to prevent flash */}
         <script

--- a/lib/supabase-server.ts
+++ b/lib/supabase-server.ts
@@ -1,12 +1,21 @@
-import { createClient } from "@supabase/supabase-js";
+import { createClient, SupabaseClient } from "@supabase/supabase-js";
 import { NextRequest } from "next/server";
 
-// Server-side Supabase client using the service role key.
-// This has full database access — only used inside API routes, never in the browser.
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+// Lazy singleton — avoids crashing during Next.js static page collection
+// when env vars aren't available yet. The client is only created on first use.
+let _supabaseAdmin: SupabaseClient | null = null;
 
-export const supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey);
+export function getSupabaseAdmin() {
+  if (!_supabaseAdmin) {
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!url || !key) {
+      throw new Error("Missing Supabase env vars");
+    }
+    _supabaseAdmin = createClient(url, key);
+  }
+  return _supabaseAdmin;
+}
 
 // Reads the Authorization header from an incoming request,
 // extracts the Bearer token, and asks Supabase to verify it.
@@ -24,7 +33,7 @@ export async function getAuthUser(request: NextRequest) {
   const {
     data: { user },
     error,
-  } = await supabaseAdmin.auth.getUser(token);
+  } = await getSupabaseAdmin().auth.getUser(token);
 
   if (error || !user) {
     return null;


### PR DESCRIPTION
## fix: resolve Vercel build crash and HTML hydration warning                                                                                                       
                                         
  ### Supabase server client was created at module import time, crashed during Next.js static page collection on env vars aren't available at that phase. Replaced the top-level createClient call with a lazy getSupabaseAdmin() singleton that  only initializes when actually called at request time. Updated all three watchlist API routes to use the new function.                                                                                                          
                                                                                                                                                                   
 ### Added suppressHydrationWarning to the <html> element in layout.tsx to silence the data-theme mismatch warning. The inline theme script intentionally changes data-theme from "dark" to "light" before React hydrates (to prevent flash), so the server/client difference is expected and handled. This is the standard pattern used by all major theme libraries.           