### PR TITLE
feat: add /group page with create and join session components

### DIFF
--- a/app/group/page.tsx
+++ b/app/group/page.tsx
@@ -1,13 +1,21 @@
 "use client";
 
 import { useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { Suspense } from "react";
 import SessionCreator from "@/components/group/SessionCreator";
 import SessionJoin from "@/components/group/SessionJoin";
 
 type Tab = "create" | "join";
 
-export default function GroupPage() {
-  const [activeTab, setActiveTab] = useState<Tab>("create");
+function GroupPageContent() {
+  const searchParams = useSearchParams();
+  const tabParam = searchParams.get("tab");
+  const codeParam = searchParams.get("code");
+
+  const [activeTab, setActiveTab] = useState<Tab>(
+    tabParam === "join" ? "join" : "create",
+  );
 
   return (
     <main
@@ -84,13 +92,26 @@ export default function GroupPage() {
           style={{
             background: "var(--surface)",
             border: "1px solid var(--border)",
-            borderRadius: "16px",
+            borderRadius: "var(--r-lg)",
             padding: "8px 20px",
+            animation: "fadeUp 0.4s ease both",
           }}
         >
-          {activeTab === "create" ? <SessionCreator /> : <SessionJoin />}
+          {activeTab === "create" ? (
+            <SessionCreator />
+          ) : (
+            <SessionJoin initialCode={codeParam ?? ""} />
+          )}
         </div>
       </div>
     </main>
+  );
+}
+
+export default function GroupPage() {
+  return (
+    <Suspense>
+      <GroupPageContent />
+    </Suspense>
   );
 }

--- a/components/dashboard/DashboardShell.tsx
+++ b/components/dashboard/DashboardShell.tsx
@@ -3,6 +3,8 @@
 import { useState, useCallback } from "react";
 import MoodBox from "./MoodBox";
 import MoodPanel from "./MoodPanel";
+import ExploreBox from "./ExploreBox";
+import ExplorePanel from "./ExplorePanel";
 
 export default function DashboardShell() {
   const [selectedMoods, setSelectedMoods] = useState<Set<string>>(new Set());
@@ -36,6 +38,10 @@ export default function DashboardShell() {
           onExpand={() => togglePanel("mood")}
           isExpanded={openPanel === "mood"}
         />
+        <ExploreBox
+          onExpand={() => togglePanel("explore")}
+          isExpanded={openPanel === "explore"}
+        />
       </div>
 
       <div style={{ padding: "0 28px" }}>
@@ -43,6 +49,10 @@ export default function DashboardShell() {
           isOpen={openPanel === "mood"}
           selectedMoods={selectedMoods}
           onSelectMood={handleSelectMood}
+          onClose={() => setOpenPanel(null)}
+        />
+        <ExplorePanel
+          isOpen={openPanel === "explore"}
           onClose={() => setOpenPanel(null)}
         />
       </div>

--- a/components/dashboard/ExploreBox.tsx
+++ b/components/dashboard/ExploreBox.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+interface ExploreBoxProps {
+  onExpand: () => void;
+  isExpanded: boolean;
+}
+
+const exploreItems = [
+  {
+    icon: "👥",
+    iconBg: "var(--gold-soft)",
+    title: "Group session",
+    sub: "Pick moods together, swipe to match",
+    active: true,
+  },
+  {
+    icon: "🎬",
+    iconBg: "var(--teal-soft)",
+    title: "Now playing",
+    sub: "In cinemas & streaming in Norway",
+    active: false,
+  },
+  {
+    icon: "🏆",
+    iconBg: "var(--violet-soft)",
+    title: "Award season",
+    sub: "Oscar nominees & winners 2025",
+    active: false,
+  },
+];
+
+export default function ExploreBox({ onExpand, isExpanded }: ExploreBoxProps) {
+  return (
+    <section
+      onClick={onExpand}
+      className="relative overflow-hidden cursor-pointer"
+      style={{
+        background: "var(--surface)",
+        border: `1px solid ${isExpanded ? "var(--border-active)" : "var(--border)"}`,
+        borderRadius: "16px",
+        padding: "22px",
+        transition: "border-color var(--t-slow), box-shadow var(--t-slow)",
+        boxShadow: isExpanded ? "0 0 0 1px var(--border-active)" : "none",
+      }}
+    >
+      {/* Label */}
+      <div
+        style={{
+          fontSize: "10px",
+          fontWeight: 600,
+          textTransform: "uppercase",
+          letterSpacing: "1.8px",
+          color: "var(--teal)",
+          marginBottom: "12px",
+        }}
+      >
+        Explore
+      </div>
+
+      {/* Heading */}
+      <h2
+        className="font-serif"
+        style={{
+          fontSize: "clamp(20px, 2.2vw, 26px)",
+          fontWeight: 600,
+          color: "var(--t1)",
+          lineHeight: 1.2,
+          marginBottom: "6px",
+        }}
+      >
+        Discover together
+      </h2>
+
+      {/* Subtext */}
+      <p
+        style={{
+          fontSize: "13px",
+          color: "var(--t2)",
+          lineHeight: 1.5,
+          marginBottom: "16px",
+        }}
+      >
+        Group sessions, what&apos;s trending, and curated picks.
+      </p>
+
+      {/* Explore items */}
+      <div
+        className="flex flex-col gap-[8px] mb-[10px]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {exploreItems.map((item) => (
+          <button
+            key={item.title}
+            onClick={onExpand}
+            className="group cursor-pointer"
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "11px",
+              padding: "10px 12px",
+              borderRadius: "11px",
+              background: "var(--surface2)",
+              border: "1px solid var(--border)",
+              transition: "all var(--t-base)",
+              opacity: item.active ? 1 : 0.45,
+              textAlign: "left",
+            }}
+          >
+            {/* Icon */}
+            <div
+              style={{
+                width: "36px",
+                height: "36px",
+                borderRadius: "9px",
+                flexShrink: 0,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                fontSize: "16px",
+                background: item.iconBg,
+              }}
+            >
+              {item.icon}
+            </div>
+
+            {/* Text */}
+            <div style={{ flex: 1 }}>
+              <div
+                style={{
+                  fontSize: "12px",
+                  fontWeight: 600,
+                  lineHeight: 1.2,
+                  color: "var(--t1)",
+                  marginBottom: "2px",
+                }}
+              >
+                {item.title}
+              </div>
+              <div
+                style={{
+                  fontSize: "11px",
+                  fontWeight: 400,
+                  lineHeight: 1.3,
+                  color: "var(--t3)",
+                }}
+              >
+                {item.active ? item.sub : "Coming soon"}
+              </div>
+            </div>
+          </button>
+        ))}
+      </div>
+
+      {/* See more button */}
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          onExpand();
+        }}
+        className="flex w-full items-center justify-center gap-[6px] cursor-pointer"
+        style={{
+          padding: "9px",
+          borderRadius: "10px",
+          background: "var(--surface2)",
+          border: "1px solid var(--border)",
+          color: "var(--t2)",
+          fontSize: "12px",
+          fontWeight: 500,
+          transition: "all var(--t-base)",
+        }}
+      >
+        <span>Start or join a session</span>
+        <span
+          style={{
+            fontSize: "11px",
+            transition: "transform var(--t-slow)",
+            transform: isExpanded ? "rotate(180deg)" : "none",
+            display: "inline-block",
+          }}
+        >
+          ↓
+        </span>
+      </button>
+    </section>
+  );
+}

--- a/components/dashboard/ExplorePanel.tsx
+++ b/components/dashboard/ExplorePanel.tsx
@@ -1,0 +1,424 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/components/AuthProvider";
+
+interface ExplorePanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const steps = [
+  {
+    num: "1",
+    title: "Create & share a code",
+    sub: "Start a session and send the code to your group",
+  },
+  {
+    num: "2",
+    title: "Everyone picks their mood",
+    sub: "Each person selects moods privately — no bias",
+  },
+  {
+    num: "3",
+    title: "Swipe & match",
+    sub: "Filmood builds a shared deck. Swipe together, watch the match",
+  },
+];
+
+export default function ExplorePanel({ isOpen, onClose }: ExplorePanelProps) {
+  const { user, session } = useAuth();
+  const router = useRouter();
+
+  const [joinMode, setJoinMode] = useState(false);
+  const [joinCode, setJoinCode] = useState("");
+  const [joinError, setJoinError] = useState<string | null>(null);
+  const [joinLoading, setJoinLoading] = useState(false);
+
+  const handleCreate = () => {
+    router.push("/group");
+  };
+
+  const handleJoin = async () => {
+    const trimmed = joinCode.trim().toUpperCase();
+    if (trimmed.length !== 6) {
+      setJoinError("Enter a 6-character code");
+      return;
+    }
+
+    setJoinError(null);
+
+    // Guests need the nickname field on the /group page
+    if (!user) {
+      router.push(`/group?tab=join&code=${trimmed}`);
+      return;
+    }
+
+    setJoinLoading(true);
+
+    try {
+      const res = await fetch("/api/group/join", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${session?.access_token}`,
+        },
+        body: JSON.stringify({ code: trimmed }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        setJoinError(data.error || "Failed to join");
+        return;
+      }
+
+      localStorage.setItem("participantId", data.participantId);
+      router.push(`/group/${data.code}`);
+    } catch {
+      setJoinError("Something went wrong");
+    } finally {
+      setJoinLoading(false);
+    }
+  };
+
+  return (
+    <div
+      style={{
+        maxHeight: isOpen ? "800px" : "0",
+        opacity: isOpen ? 1 : 0,
+        overflow: "hidden",
+        transition:
+          "max-height 0.5s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.4s, padding 0.4s",
+        paddingBottom: isOpen ? "10px" : "0",
+      }}
+    >
+      <div
+        style={{
+          background: "var(--surface)",
+          border: "1px solid var(--border)",
+          borderRadius: "16px",
+          padding: "22px",
+        }}
+      >
+        {/* Panel label */}
+        <div
+          style={{
+            fontSize: "10px",
+            fontWeight: 600,
+            textTransform: "uppercase",
+            letterSpacing: "1.8px",
+            color: "var(--teal)",
+            marginBottom: "20px",
+          }}
+        >
+          Start a group session
+        </div>
+
+        {/* Steps */}
+        <div className="flex flex-col gap-[16px]" style={{ marginBottom: "24px" }}>
+          {steps.map((step) => (
+            <div key={step.num} className="flex items-start gap-[12px]">
+              {/* Step number */}
+              <div
+                style={{
+                  width: "32px",
+                  height: "32px",
+                  borderRadius: "8px",
+                  flexShrink: 0,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  fontSize: "13px",
+                  fontWeight: 700,
+                  background: "var(--teal-soft)",
+                  color: "var(--teal)",
+                }}
+              >
+                {step.num}
+              </div>
+
+              {/* Step text */}
+              <div>
+                <div
+                  style={{
+                    fontSize: "14px",
+                    fontWeight: 600,
+                    color: "var(--t1)",
+                    lineHeight: 1.3,
+                    marginBottom: "2px",
+                  }}
+                >
+                  {step.title}
+                </div>
+                <div
+                  style={{
+                    fontSize: "12px",
+                    color: "var(--t3)",
+                    lineHeight: 1.4,
+                  }}
+                >
+                  {step.sub}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Actions */}
+        {user ? (
+          // Logged-in user actions
+          <div
+            style={{ borderTop: "1px solid var(--border)", paddingTop: "16px" }}
+          >
+            {!joinMode ? (
+              <div className="flex items-center gap-[10px] flex-wrap">
+                <button
+                  onClick={handleCreate}
+                  className="cursor-pointer font-sans"
+                  style={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: "6px",
+                    padding: "10px 20px",
+                    borderRadius: "10px",
+                    background: "var(--teal)",
+                    color: "#0a0a0c",
+                    fontSize: "13px",
+                    fontWeight: 600,
+                    lineHeight: 1,
+                    border: "none",
+                    transition: "all var(--t-base)",
+                  }}
+                >
+                  Create session
+                </button>
+
+                <button
+                  onClick={() => setJoinMode(true)}
+                  className="cursor-pointer font-sans"
+                  style={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    padding: "9px 18px",
+                    borderRadius: "10px",
+                    background: "none",
+                    color: "var(--t2)",
+                    fontSize: "13px",
+                    fontWeight: 500,
+                    lineHeight: 1,
+                    border: "1px solid var(--border)",
+                    transition: "all var(--t-base)",
+                  }}
+                >
+                  Join with code
+                </button>
+
+                <button
+                  onClick={onClose}
+                  className="cursor-pointer font-sans"
+                  style={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    padding: "9px 18px",
+                    borderRadius: "10px",
+                    background: "none",
+                    color: "var(--t2)",
+                    fontSize: "13px",
+                    fontWeight: 500,
+                    lineHeight: 1,
+                    border: "1px solid var(--border)",
+                    transition: "all var(--t-base)",
+                  }}
+                >
+                  Close
+                </button>
+
+                <span
+                  className="ml-auto"
+                  style={{ fontSize: "12px", color: "var(--t3)" }}
+                >
+                  Guests can join with a code — no account needed
+                </span>
+              </div>
+            ) : (
+              // Join code input
+              <div className="flex flex-col gap-[10px]">
+                <div className="flex gap-[8px]">
+                  <input
+                    type="text"
+                    value={joinCode}
+                    onChange={(e) => {
+                      setJoinCode(e.target.value.toUpperCase().slice(0, 6));
+                      setJoinError(null);
+                    }}
+                    placeholder="ENTER CODE"
+                    maxLength={6}
+                    autoFocus
+                    className="font-sans"
+                    style={{
+                      flex: 1,
+                      maxWidth: "200px",
+                      padding: "10px 14px",
+                      borderRadius: "var(--r)",
+                      background: "var(--surface2)",
+                      border: "1px solid var(--border)",
+                      color: "var(--t1)",
+                      fontSize: "15px",
+                      fontWeight: 600,
+                      letterSpacing: "3px",
+                      textAlign: "center",
+                      textTransform: "uppercase",
+                      outline: "none",
+                      transition: "border-color var(--t-fast)",
+                    }}
+                    onFocus={(e) =>
+                      (e.target.style.borderColor = "var(--border-active)")
+                    }
+                    onBlur={(e) =>
+                      (e.target.style.borderColor = "var(--border)")
+                    }
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") {
+                        e.preventDefault();
+                        handleJoin();
+                      }
+                    }}
+                  />
+
+                  <button
+                    onClick={handleJoin}
+                    disabled={joinLoading}
+                    className="cursor-pointer font-sans"
+                    style={{
+                      padding: "10px 20px",
+                      borderRadius: "10px",
+                      background: joinLoading
+                        ? "var(--surface2)"
+                        : "var(--teal)",
+                      color: joinLoading ? "var(--t3)" : "#0a0a0c",
+                      fontSize: "13px",
+                      fontWeight: 600,
+                      border: "none",
+                      transition: "all var(--t-fast)",
+                    }}
+                  >
+                    {joinLoading ? "Joining..." : "Join"}
+                  </button>
+
+                  <button
+                    onClick={() => {
+                      setJoinMode(false);
+                      setJoinCode("");
+                      setJoinError(null);
+                    }}
+                    className="cursor-pointer font-sans"
+                    style={{
+                      padding: "9px 14px",
+                      borderRadius: "10px",
+                      background: "none",
+                      color: "var(--t3)",
+                      fontSize: "13px",
+                      fontWeight: 500,
+                      border: "1px solid var(--border)",
+                      transition: "all var(--t-base)",
+                    }}
+                  >
+                    Back
+                  </button>
+                </div>
+
+                {joinError && (
+                  <p style={{ fontSize: "12px", color: "var(--rose)" }}>
+                    {joinError}
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
+        ) : (
+          // Guest prompt
+          <div
+            style={{ borderTop: "1px solid var(--border)", paddingTop: "16px" }}
+          >
+            <div
+              style={{
+                fontSize: "14px",
+                fontWeight: 600,
+                color: "var(--t1)",
+                marginBottom: "4px",
+              }}
+            >
+              Create an account to host
+            </div>
+            <p
+              style={{
+                fontSize: "12px",
+                color: "var(--t3)",
+                lineHeight: 1.5,
+                marginBottom: "14px",
+              }}
+            >
+              Sign up to create group sessions. You can join existing sessions as
+              a guest.
+            </p>
+
+            <div className="flex items-center gap-[10px] flex-wrap">
+              <button
+                onClick={() => router.push("/signup")}
+                className="cursor-pointer font-sans"
+                style={{
+                  padding: "10px 20px",
+                  borderRadius: "10px",
+                  background: "var(--teal)",
+                  color: "#0a0a0c",
+                  fontSize: "13px",
+                  fontWeight: 600,
+                  border: "none",
+                  transition: "all var(--t-base)",
+                }}
+              >
+                Sign up free
+              </button>
+
+              <button
+                onClick={() => router.push("/group?tab=join")}
+                className="cursor-pointer font-sans"
+                style={{
+                  padding: "9px 18px",
+                  borderRadius: "10px",
+                  background: "none",
+                  color: "var(--t2)",
+                  fontSize: "13px",
+                  fontWeight: 500,
+                  border: "1px solid var(--border)",
+                  transition: "all var(--t-base)",
+                }}
+              >
+                Join with code
+              </button>
+
+              <button
+                onClick={onClose}
+                className="cursor-pointer font-sans"
+                style={{
+                  padding: "9px 18px",
+                  borderRadius: "10px",
+                  background: "none",
+                  color: "var(--t2)",
+                  fontSize: "13px",
+                  fontWeight: 500,
+                  border: "1px solid var(--border)",
+                  transition: "all var(--t-base)",
+                }}
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/group/SessionCreator.tsx
+++ b/components/group/SessionCreator.tsx
@@ -68,7 +68,7 @@ export default function SessionCreator() {
           className="font-sans"
           style={{
             padding: "10px 24px",
-            borderRadius: "10px",
+            borderRadius: "var(--r)",
             background: "var(--gold)",
             color: "#000",
             fontSize: "14px",
@@ -101,10 +101,11 @@ export default function SessionCreator() {
             letterSpacing: "6px",
             color: "var(--gold)",
             background: "var(--surface2)",
-            border: "1px solid var(--border)",
-            borderRadius: "12px",
+            border: `1px solid ${copied ? "var(--gold)" : "var(--border)"}`,
+            borderRadius: "var(--r)",
             padding: "16px 32px",
-            transition: "all 0.2s",
+            transition: "all var(--t-base)",
+            boxShadow: copied ? "0 0 20px var(--gold-glow)" : "none",
           }}
         >
           {code}
@@ -114,7 +115,7 @@ export default function SessionCreator() {
           style={{
             fontSize: "12px",
             color: copied ? "var(--gold)" : "var(--t3)",
-            transition: "color 0.2s",
+            transition: "color var(--t-fast)",
           }}
         >
           {copied ? "Copied!" : "Click code to copy"}
@@ -125,13 +126,13 @@ export default function SessionCreator() {
           className="cursor-pointer font-sans"
           style={{
             padding: "12px 32px",
-            borderRadius: "10px",
+            borderRadius: "var(--r)",
             background: "var(--gold)",
             color: "#000",
             fontSize: "14px",
             fontWeight: 600,
             border: "none",
-            transition: "opacity 0.2s",
+            transition: "opacity var(--t-fast)",
           }}
         >
           Go to lobby
@@ -165,13 +166,13 @@ export default function SessionCreator() {
         className="cursor-pointer font-sans"
         style={{
           padding: "12px 32px",
-          borderRadius: "10px",
+          borderRadius: "var(--r)",
           background: loading ? "var(--surface2)" : "var(--gold)",
           color: loading ? "var(--t3)" : "#000",
           fontSize: "14px",
           fontWeight: 600,
           border: "none",
-          transition: "all 0.2s",
+          transition: "all var(--t-base)",
           opacity: loading ? 0.7 : 1,
         }}
       >

--- a/components/group/SessionJoin.tsx
+++ b/components/group/SessionJoin.tsx
@@ -4,11 +4,15 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/components/AuthProvider";
 
-export default function SessionJoin() {
+interface SessionJoinProps {
+  initialCode?: string;
+}
+
+export default function SessionJoin({ initialCode = "" }: SessionJoinProps) {
   const { user, session } = useAuth();
   const router = useRouter();
 
-  const [code, setCode] = useState("");
+  const [code, setCode] = useState(initialCode);
   const [nickname, setNickname] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -85,14 +89,14 @@ export default function SessionJoin() {
         type="text"
         value={code}
         onChange={(e) => setCode(e.target.value.toUpperCase().slice(0, 6))}
-        placeholder="Enter code"
+        placeholder="ENTER CODE"
         maxLength={6}
         className="font-sans"
         style={{
           width: "100%",
           maxWidth: "280px",
           padding: "14px 16px",
-          borderRadius: "10px",
+          borderRadius: "var(--r)",
           background: "var(--surface2)",
           border: "1px solid var(--border)",
           color: "var(--t1)",
@@ -102,33 +106,52 @@ export default function SessionJoin() {
           textAlign: "center",
           textTransform: "uppercase",
           outline: "none",
-          transition: "border-color 0.2s",
+          transition: "border-color var(--t-fast)",
         }}
+        onFocus={(e) => (e.target.style.borderColor = "var(--border-active)")}
+        onBlur={(e) => (e.target.style.borderColor = "var(--border)")}
       />
 
       {/* Nickname field — only for guests */}
       {!user && (
-        <input
-          type="text"
-          value={nickname}
-          onChange={(e) => setNickname(e.target.value.slice(0, 20))}
-          placeholder="Your nickname"
-          maxLength={20}
-          className="font-sans"
-          style={{
-            width: "100%",
-            maxWidth: "280px",
-            padding: "12px 16px",
-            borderRadius: "10px",
-            background: "var(--surface2)",
-            border: "1px solid var(--border)",
-            color: "var(--t1)",
-            fontSize: "14px",
-            textAlign: "center",
-            outline: "none",
-            transition: "border-color 0.2s",
-          }}
-        />
+        <div style={{ width: "100%", maxWidth: "280px" }}>
+          <label
+            style={{
+              display: "block",
+              fontSize: "10px",
+              fontWeight: 600,
+              textTransform: "uppercase",
+              letterSpacing: "1.5px",
+              color: "var(--t3)",
+              marginBottom: "6px",
+              textAlign: "center",
+            }}
+          >
+            Joining as guest
+          </label>
+          <input
+            type="text"
+            value={nickname}
+            onChange={(e) => setNickname(e.target.value.slice(0, 20))}
+            placeholder="Your nickname"
+            maxLength={20}
+            className="font-sans"
+            style={{
+              width: "100%",
+              padding: "12px 16px",
+              borderRadius: "var(--r)",
+              background: "var(--surface2)",
+              border: "1px solid var(--border)",
+              color: "var(--t1)",
+              fontSize: "14px",
+              textAlign: "center",
+              outline: "none",
+              transition: "border-color var(--t-fast)",
+            }}
+            onFocus={(e) => (e.target.style.borderColor = "var(--border-active)")}
+            onBlur={(e) => (e.target.style.borderColor = "var(--border)")}
+          />
+        </div>
       )}
 
       {error && (
@@ -141,13 +164,13 @@ export default function SessionJoin() {
         className="cursor-pointer font-sans"
         style={{
           padding: "12px 32px",
-          borderRadius: "10px",
+          borderRadius: "var(--r)",
           background: loading ? "var(--surface2)" : "var(--gold)",
           color: loading ? "var(--t3)" : "#000",
           fontSize: "14px",
           fontWeight: 600,
           border: "none",
-          transition: "all 0.2s",
+          transition: "all var(--t-base)",
           opacity: loading ? 0.7 : 1,
         }}
       >


### PR DESCRIPTION
## feat: add /group page with create and join session components

- Group page with tab toggle between Create and Join
- `SessionCreator`: auth-gated, generates code, copy-to-clipboard, routes to lobby
- `SessionJoin`: code input, guest nickname field, validation, routes to lobby
- Persists `participantId` in `localStorage` for guest identification