### PR TITLE
feat: add lobby API routes and session expiry logic

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "liveServer.settings.port": 5501
+}

--- a/app/api/group/[code]/leave/route.ts
+++ b/app/api/group/[code]/leave/route.ts
@@ -1,0 +1,119 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseAdmin, getAuthUser } from "@/lib/supabase-server";
+
+// DELETE /api/group/[code]/leave
+// Removes a participant from the session.
+// If the host leaves, the entire session is deleted.
+// Auth optional — guests identify via participantId in the request body.
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ code: string }> },
+) {
+  const user = await getAuthUser(request);
+  const { code } = await params;
+
+  // Guests send their participantId in the body
+  let participantId: string | null = null;
+  try {
+    const body = await request.json();
+    participantId = body.participantId ?? null;
+  } catch {
+    // No body is fine for authenticated users
+  }
+
+  // Must have some way to identify the participant
+  if (!user && !participantId) {
+    return NextResponse.json(
+      { error: "Unauthorized" },
+      { status: 401 },
+    );
+  }
+
+  try {
+    const supabase = getSupabaseAdmin();
+    const upperCode = code.toUpperCase();
+
+    // Fetch the session
+    const { data: session, error: sessionError } = await supabase
+      .from("sessions")
+      .select("id, host_id, status")
+      .eq("code", upperCode)
+      .single();
+
+    if (sessionError || !session) {
+      return NextResponse.json(
+        { error: "Session not found" },
+        { status: 404 },
+      );
+    }
+
+    // Can only leave during lobby phase
+    if (session.status !== "lobby") {
+      return NextResponse.json(
+        { error: "Cannot leave a session that has already started" },
+        { status: 400 },
+      );
+    }
+
+    // Find the participant row
+    let participantQuery = supabase
+      .from("session_participants")
+      .select("id, user_id")
+      .eq("session_id", session.id);
+
+    if (user) {
+      participantQuery = participantQuery.eq("user_id", user.id);
+    } else {
+      participantQuery = participantQuery.eq("id", participantId!);
+    }
+
+    const { data: participant, error: participantError } =
+      await participantQuery.single();
+
+    if (participantError || !participant) {
+      return NextResponse.json(
+        { error: "You are not in this session" },
+        { status: 404 },
+      );
+    }
+
+    // Check if this participant is the host
+    const isHost = participant.user_id === session.host_id;
+
+    if (isHost) {
+      // Host leaving = delete entire session (cascade removes participants)
+      const { error: deleteError } = await supabase
+        .from("sessions")
+        .delete()
+        .eq("id", session.id);
+
+      if (deleteError) {
+        return NextResponse.json(
+          { error: "Failed to disband session" },
+          { status: 500 },
+        );
+      }
+
+      return NextResponse.json({ disbanded: true });
+    }
+
+    // Non-host: just remove their participant row
+    const { error: deleteError } = await supabase
+      .from("session_participants")
+      .delete()
+      .eq("id", participant.id);
+
+    if (deleteError) {
+      return NextResponse.json(
+        { error: "Failed to leave session" },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({ left: true });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to leave session";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/api/group/[code]/route.ts
+++ b/app/api/group/[code]/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseAdmin } from "@/lib/supabase-server";
+import { isSessionExpired } from "@/lib/group";
+
+// GET /api/group/[code]
+// Returns session details + participant list for the lobby.
+// Auth is not required — guests need to see the lobby too.
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ code: string }> },
+) {
+  const { code } = await params;
+
+  if (!code || code.length !== 6) {
+    return NextResponse.json(
+      { error: "Invalid session code" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const supabase = getSupabaseAdmin();
+    const upperCode = code.toUpperCase();
+
+    // Fetch the session
+    const { data: session, error: sessionError } = await supabase
+      .from("sessions")
+      .select("id, code, host_id, status, created_at")
+      .eq("code", upperCode)
+      .single();
+
+    if (sessionError || !session) {
+      return NextResponse.json(
+        { error: "Session not found" },
+        { status: 404 },
+      );
+    }
+
+    if (isSessionExpired(session.created_at)) {
+      return NextResponse.json(
+        { error: "Session expired" },
+        { status: 410 },
+      );
+    }
+
+    // Fetch participants ordered by join time (host will be first)
+    const { data: participants, error: participantsError } = await supabase
+      .from("session_participants")
+      .select("id, nickname, user_id, joined_at")
+      .eq("session_id", session.id)
+      .order("joined_at", { ascending: true });
+
+    if (participantsError) {
+      return NextResponse.json(
+        { error: "Failed to load participants" },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({
+      session: {
+        id: session.id,
+        code: session.code,
+        host_id: session.host_id,
+        status: session.status,
+        created_at: session.created_at,
+      },
+      participants: participants ?? [],
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to load session";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/api/group/[code]/start/route.ts
+++ b/app/api/group/[code]/start/route.ts
@@ -1,0 +1,95 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseAdmin, getAuthUser } from "@/lib/supabase-server";
+import { isSessionExpired } from "@/lib/group";
+
+// POST /api/group/[code]/start
+// Host transitions the session from "lobby" to "mood".
+// Only the session host can call this. Requires at least 2 participants.
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ code: string }> },
+) {
+  const user = await getAuthUser(request);
+  if (!user) {
+    return NextResponse.json(
+      { error: "Unauthorized" },
+      { status: 401 },
+    );
+  }
+
+  const { code } = await params;
+
+  try {
+    const supabase = getSupabaseAdmin();
+    const upperCode = code.toUpperCase();
+
+    // Fetch the session
+    const { data: session, error: sessionError } = await supabase
+      .from("sessions")
+      .select("id, host_id, status, created_at")
+      .eq("code", upperCode)
+      .single();
+
+    if (sessionError || !session) {
+      return NextResponse.json(
+        { error: "Session not found" },
+        { status: 404 },
+      );
+    }
+
+    if (isSessionExpired(session.created_at)) {
+      return NextResponse.json(
+        { error: "Session expired" },
+        { status: 410 },
+      );
+    }
+
+    // Only the host can start
+    if (session.host_id !== user.id) {
+      return NextResponse.json(
+        { error: "Only the host can start the session" },
+        { status: 403 },
+      );
+    }
+
+    // Must be in lobby phase
+    if (session.status !== "lobby") {
+      return NextResponse.json(
+        { error: "Session is not in lobby state" },
+        { status: 400 },
+      );
+    }
+
+    // Need at least 2 participants
+    const { count } = await supabase
+      .from("session_participants")
+      .select("id", { count: "exact", head: true })
+      .eq("session_id", session.id);
+
+    if (count === null || count < 2) {
+      return NextResponse.json(
+        { error: "Need at least 2 participants to start" },
+        { status: 400 },
+      );
+    }
+
+    // Transition to mood phase
+    const { error: updateError } = await supabase
+      .from("sessions")
+      .update({ status: "mood" })
+      .eq("id", session.id);
+
+    if (updateError) {
+      return NextResponse.json(
+        { error: "Failed to start session" },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({ status: "mood" });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to start session";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/api/group/join/route.ts
+++ b/app/api/group/join/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin, getAuthUser } from "@/lib/supabase-server";
-import { MAX_PARTICIPANTS } from "@/lib/group";
+import { MAX_PARTICIPANTS, isSessionExpired } from "@/lib/group";
 
 // POST /api/group/join
 // Joins an existing group session by code.
@@ -44,7 +44,7 @@ export async function POST(request: NextRequest) {
     // Find the session
     const { data: session, error: sessionError } = await supabase
       .from("sessions")
-      .select("id, status")
+      .select("id, status, created_at")
       .eq("code", upperCode)
       .single();
 
@@ -52,6 +52,13 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         { error: "Session not found. Check the code and try again." },
         { status: 404 },
+      );
+    }
+
+    if (isSessionExpired(session.created_at)) {
+      return NextResponse.json(
+        { error: "Session expired" },
+        { status: 410 },
       );
     }
 

--- a/components/dashboard/ExploreBox.tsx
+++ b/components/dashboard/ExploreBox.tsx
@@ -85,7 +85,7 @@ export default function ExploreBox({ onExpand, isExpanded }: ExploreBoxProps) {
 
       {/* Explore items */}
       <div
-        className="flex flex-col gap-[8px] mb-[10px]"
+        className="flex flex-col gap-2 mb-2.5"
         onClick={(e) => e.stopPropagation()}
       >
         {exploreItems.map((item) => (
@@ -157,7 +157,7 @@ export default function ExploreBox({ onExpand, isExpanded }: ExploreBoxProps) {
           e.stopPropagation();
           onExpand();
         }}
-        className="flex w-full items-center justify-center gap-[6px] cursor-pointer"
+        className="flex w-full items-center justify-center gap-1.5 cursor-pointer"
         style={{
           padding: "9px",
           borderRadius: "10px",

--- a/components/dashboard/ExplorePanel.tsx
+++ b/components/dashboard/ExplorePanel.tsx
@@ -117,9 +117,9 @@ export default function ExplorePanel({ isOpen, onClose }: ExplorePanelProps) {
         </div>
 
         {/* Steps */}
-        <div className="flex flex-col gap-[16px]" style={{ marginBottom: "24px" }}>
+        <div className="flex flex-col gap-4" style={{ marginBottom: "24px" }}>
           {steps.map((step) => (
-            <div key={step.num} className="flex items-start gap-[12px]">
+            <div key={step.num} className="flex items-start gap-3">
               {/* Step number */}
               <div
                 style={{
@@ -173,7 +173,7 @@ export default function ExplorePanel({ isOpen, onClose }: ExplorePanelProps) {
             style={{ borderTop: "1px solid var(--border)", paddingTop: "16px" }}
           >
             {!joinMode ? (
-              <div className="flex items-center gap-[10px] flex-wrap">
+              <div className="flex items-center gap-2.5 flex-wrap">
                 <button
                   onClick={handleCreate}
                   className="cursor-pointer font-sans"
@@ -244,8 +244,8 @@ export default function ExplorePanel({ isOpen, onClose }: ExplorePanelProps) {
               </div>
             ) : (
               // Join code input
-              <div className="flex flex-col gap-[10px]">
-                <div className="flex gap-[8px]">
+              <div className="flex flex-col gap-2.5">
+                <div className="flex gap-2">
                   <input
                     type="text"
                     value={joinCode}
@@ -364,7 +364,7 @@ export default function ExplorePanel({ isOpen, onClose }: ExplorePanelProps) {
               a guest.
             </p>
 
-            <div className="flex items-center gap-[10px] flex-wrap">
+            <div className="flex items-center gap-2.5 flex-wrap">
               <button
                 onClick={() => router.push("/signup")}
                 className="cursor-pointer font-sans"

--- a/lib/group.ts
+++ b/lib/group.ts
@@ -4,7 +4,8 @@ import { getSupabaseAdmin } from "@/lib/supabase-server";
 // Excluded: 0/O (zero vs oh), 1/I/L (one vs I vs L)
 const CODE_CHARS = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
 const CODE_LENGTH = 6;
-const MAX_PARTICIPANTS = 8;
+const MAX_PARTICIPANTS = 10;
+const SESSION_EXPIRY_HOURS = 4;
 
 /** Generate a random 6-char code like "HK7T4N" */
 function generateCode(): string {
@@ -37,4 +38,11 @@ export async function generateUniqueCode(): Promise<string> {
   throw new Error("Failed to generate unique code");
 }
 
-export { MAX_PARTICIPANTS };
+/** Check if a session has passed the expiry window */
+function isSessionExpired(createdAt: string): boolean {
+  const created = new Date(createdAt).getTime();
+  const now = Date.now();
+  return now - created > SESSION_EXPIRY_HOURS * 60 * 60 * 1000;
+}
+
+export { MAX_PARTICIPANTS, SESSION_EXPIRY_HOURS, isSessionExpired };


### PR DESCRIPTION
  ## feat(group-lobby): add lobby API routes and session expiry logic

---

### Files Changed
- `lib/group.ts`  
  - Increased `MAX_PARTICIPANTS` to 10  
  - Added `SESSION_EXPIRY_HOURS` (4 hours)  
  - Introduced `isSessionExpired()` helper  

- `app/api/group/join/route.ts`  
  - Added session expiry validation  
  - Now selects `created_at` and rejects expired sessions  

---

### Files Created
- `app/api/group/[code]/route.ts`  
  - `GET` — Returns lobby state (session + participants)  

- `app/api/group/[code]/start/route.ts`  
  - `POST` — Allows host to start session (lobby → mood state)  

- `app/api/group/[code]/leave/route.ts`  
  - `DELETE` —  
    - Host: disbands session  
    - Participant: leaves session  

---