### PR TITLE
feat/results-page-layout-polish

### DIFF
--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -2,10 +2,179 @@
 
 import { useSearchParams } from "next/navigation";
 import { useState, useEffect, Suspense } from "react";
-import FilmGrid from "@/components/film/FilmGrid";
 import Link from "next/link";
-import type { Film } from "@/lib/types";
+import FilmGrid from "@/components/film/FilmGrid";
+import type { Film, AccentColor } from "@/lib/types";
+import { moodMap } from "@/lib/moodMap";
 
+/* Accent system */
+const accentVars: Record<
+  AccentColor,
+  { base: string; soft: string; glow: string }
+> = {
+  gold: {
+    base: "var(--gold)",
+    soft: "var(--gold-soft)",
+    glow: "var(--gold-glow)",
+  },
+  blue: {
+    base: "var(--blue)",
+    soft: "var(--blue-soft)",
+    glow: "var(--blue-glow)",
+  },
+  rose: {
+    base: "var(--rose)",
+    soft: "var(--rose-soft)",
+    glow: "var(--rose-glow)",
+  },
+  violet: {
+    base: "var(--violet)",
+    soft: "var(--violet-soft)",
+    glow: "var(--violet-glow)",
+  },
+  teal: {
+    base: "var(--teal)",
+    soft: "var(--teal-soft)",
+    glow: "var(--teal-glow)",
+  },
+  ember: {
+    base: "var(--ember)",
+    soft: "var(--ember-soft)",
+    glow: "var(--ember-glow)",
+  },
+};
+
+function getMeta(moods: string[]) {
+  const key = moods[0]?.trim().toLowerCase() ?? "";
+  const mood = moodMap[key];
+
+  return {
+    accent: (mood?.accentColor ?? "gold") as AccentColor,
+    tagline: mood?.description ?? "Films picked just for this moment.",
+    label: mood?.label ?? "Your Matches",
+  };
+}
+
+/* Hero */
+function Hero({ moods, filmCount }: { moods: string[]; filmCount: number }) {
+  const { accent: accentKey, tagline } = getMeta(moods);
+  const accent = accentVars[accentKey];
+
+  return (
+    <div
+      style={{
+        width: "100%",
+        borderRadius: "var(--r-lg)",
+        border: "1px solid var(--border)",
+        background: "var(--surface)",
+        marginBottom: "32px",
+        padding: "clamp(28px, 5vw, 44px) clamp(20px, 5vw, 40px)",
+      }}
+    >
+      <Link
+        href="/"
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: "5px",
+          fontSize: "11px",
+          fontWeight: 500,
+          color: "var(--t3)",
+          textDecoration: "none",
+          marginBottom: "16px",
+          letterSpacing: "0.04em",
+          textTransform: "uppercase",
+        }}
+      >
+        ← Back
+      </Link>
+
+      <div
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          gap: "6px",
+          marginBottom: "12px",
+        }}
+      >
+        {moods.map((m) => {
+          const moodKey = m.trim().toLowerCase();
+          const moodAccentKey = moodMap[moodKey]?.accentColor ?? "gold";
+          const moodAccent = accentVars[moodAccentKey];
+
+          return (
+            <span
+              key={m}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                padding: "4px 10px",
+                borderRadius: "999px",
+                fontSize: "10px",
+                fontWeight: 600,
+                letterSpacing: "0.15em",
+                textTransform: "uppercase",
+                color: moodAccent.base,
+                background: moodAccent.soft,
+                border: `1px solid ${moodAccent.soft}`,
+              }}
+            >
+              {moodMap[moodKey]?.tagLabel ?? moodMap[moodKey]?.label ?? m}
+            </span>
+          );
+        })}
+      </div>
+
+      <h1
+        className="font-serif"
+        style={{
+          fontSize: "clamp(24px, 4vw, 34px)",
+          fontWeight: 700,
+          color: "var(--t1)",
+          margin: "0 0 8px",
+          letterSpacing: "-0.5px",
+          lineHeight: 1.1,
+        }}
+      >
+        Your Matches
+      </h1>
+
+      <p
+        style={{
+          fontSize: "14px",
+          color: "var(--t2)",
+          margin: "0 0 18px",
+          lineHeight: 1.6,
+        }}
+      >
+        {tagline}
+      </p>
+
+      {filmCount > 0 && (
+        <div
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: "6px",
+            padding: "5px 12px",
+            borderRadius: "var(--r)",
+            background: "var(--surface2)",
+            border: "1px solid var(--border)",
+            fontSize: "12px",
+            color: "var(--t2)",
+          }}
+        >
+          <span style={{ color: accent.base, fontWeight: 600 }}>
+            {filmCount}
+          </span>
+          films found
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* Results content */
 function ResultsContent() {
   const searchParams = useSearchParams();
   const mood = searchParams.get("mood");
@@ -21,15 +190,33 @@ function ResultsContent() {
       return;
     }
 
+    const parsedMoods = mood
+      .split(",")
+      .map((m) => m.trim().toLowerCase())
+      .filter(Boolean);
+
     const fetchFilms = async () => {
       try {
-        const res = await fetch(`/api/movies/discover?mood=${mood}`);
+        setLoading(true);
+        setError(null);
+
+        setMoods(parsedMoods);
+
+        const res = await fetch(
+          `/api/movies/discover?mood=${encodeURIComponent(mood)}`,
+        );
+
         const data = await res.json();
 
-        if (data.error) throw new Error(data.error);
+        if (!res.ok) {
+          throw new Error(data.error || "Failed to load films");
+        }
 
-        setFilms(data.films);
-        setMoods(data.moods || [mood]);
+        if (data.error) {
+          throw new Error(data.error);
+        }
+
+        setFilms(Array.isArray(data.films) ? data.films : []);
       } catch (err) {
         setError(err instanceof Error ? err.message : "Failed to load films");
       } finally {
@@ -39,12 +226,16 @@ function ResultsContent() {
 
     fetchFilms();
   }, [mood]);
-
   if (!mood) {
     return (
       <div className="text-center py-20">
-        <p style={{ color: "var(--t2)" }} className="mb-4">No mood selected.</p>
-        <Link href="/" style={{ color: "var(--t1)", textDecoration: "underline" }}>
+        <p style={{ color: "var(--t2)" }} className="mb-4">
+          No mood selected.
+        </p>
+        <Link
+          href="/"
+          style={{ color: "var(--t1)", textDecoration: "underline" }}
+        >
           Pick a mood first
         </Link>
       </div>
@@ -52,27 +243,28 @@ function ResultsContent() {
   }
 
   if (loading) {
-    return <p style={{ color: "var(--t2)" }} className="py-12">Loading films...</p>;
+    return (
+      <p style={{ color: "var(--t2)" }} className="py-12">
+        Loading films...
+      </p>
+    );
   }
 
   if (error) {
-    return <p style={{ color: "var(--rose)" }} className="py-12">{error}</p>;
+    return (
+      <p style={{ color: "var(--rose)" }} className="py-12">
+        {error}
+      </p>
+    );
   }
+
+  const { accent: accentKey } = getMeta(moods);
+  const accentBase = accentVars[accentKey].base;
 
   return (
     <>
-      <h1
-        className="font-serif mb-2"
-        style={{ fontSize: "28px", fontWeight: 600, color: "var(--t1)" }}
-      >
-        Your Matches
-      </h1>
-      <p style={{ color: "var(--t2)", marginBottom: "32px" }}>
-        {moods.length > 1
-          ? `Moods: ${moods.join(" + ")}`
-          : `Mood: ${moods[0]}`}
-      </p>
-      <FilmGrid films={films} />
+      <Hero moods={moods} filmCount={films.length} />
+      <FilmGrid films={films} accentBase={accentBase} />
       <Link
         href="/"
         className="mt-8 text-sm"
@@ -84,10 +276,11 @@ function ResultsContent() {
   );
 }
 
+/* ─── Page ─────────────────────────────────────────────────────────── */
 export default function ResultsPage() {
   return (
     <main
-      className="flex min-h-screen flex-col items-center px-4 pt-24 pb-12"
+      className="flex min-h-screen flex-col items-center px-4 pt-8 pb-12"
       style={{ background: "var(--bg)" }}
     >
       <Suspense fallback={<p style={{ color: "var(--t2)" }}>Loading...</p>}>

--- a/components/film/FilmCard.tsx
+++ b/components/film/FilmCard.tsx
@@ -20,12 +20,13 @@ import Link from "next/link";
 // These are the values the parent component must pass in.
 // They come directly from the TMDB API response.
 interface FilmCardProps {
-  id: number; // TMDB movie ID (used for the link)
-  title: string; // Film title
-  posterPath: string | null; // TMDB poster path (e.g. "/abc123.jpg") — can be null
-  releaseDate: string; // e.g. "2024-05-15"
-  voteAverage: number; // Rating out of 10 (e.g. 7.8)
-  overview: string; // Short film description
+  id: number;
+  title: string;
+  posterPath: string | null;
+  releaseDate: string;
+  voteAverage: number;
+  overview: string;
+  accentBase?: string;
 }
 
 export default function FilmCard({
@@ -35,46 +36,115 @@ export default function FilmCard({
   releaseDate,
   voteAverage,
   overview,
+  accentBase,
 }: FilmCardProps) {
-  // Extract just the year from "2024-05-15" → 2024
   const year = releaseDate ? new Date(releaseDate).getFullYear() : "N/A";
-
-  // Round rating to 1 decimal: 7.812 → "7.8"
-  const rating = voteAverage?.toFixed(1);
+  const rating = voteAverage?.toFixed(1) ?? "N/A";
+  const accent = accentBase ?? "var(--gold)";
 
   return (
-    // The whole card is a link to the film detail page
-    <Link href={`/film/${id}`} className="group">
-      <div className="rounded-xl overflow-hidden bg-white/5 border border-white/10 hover:border-white/30 transition-all duration-200">
-        {/* ---------- Poster Image ---------- */}
-        {/* aspect-[2/3] keeps the movie poster ratio (portrait) */}
-        <div className="relative aspect-[2/3] bg-white/10">
+    <Link
+      href={`/film/${id}`}
+      className="group"
+      style={{ textDecoration: "none" }}
+    >
+      <div
+        style={{
+          borderRadius: "var(--r)",
+          overflow: "hidden",
+          background: "var(--surface)",
+          border: "1px solid var(--border)",
+          transition:
+            "border-color var(--t-fast), transform var(--t-fast), box-shadow var(--t-fast)",
+        }}
+        onMouseEnter={(e) => {
+          const card = e.currentTarget as HTMLDivElement;
+          card.style.borderColor = accent;
+          card.style.transform = "translateY(-2px)";
+          card.style.boxShadow = "0 8px 24px rgba(0,0,0,0.12)";
+        }}
+        onMouseLeave={(e) => {
+          const card = e.currentTarget as HTMLDivElement;
+          card.style.borderColor = "var(--border)";
+          card.style.transform = "none";
+          card.style.boxShadow = "none";
+        }}
+      >
+        <div
+          className="relative aspect-[2/3]"
+          style={{ background: "var(--surface2)" }}
+        >
           {posterPath ? (
             <Image
               src={`https://image.tmdb.org/t/p/w500${posterPath}`}
               alt={title}
               fill
-              className="object-cover group-hover:scale-105 transition-transform duration-300"
+              className="object-cover"
+              style={{ transition: "transform var(--t-slow)" }}
               sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
             />
           ) : (
-            // Fallback when TMDB has no poster for this film
-            <div className="w-full h-full flex items-center justify-center text-white/30">
+            <div
+              className="w-full h-full flex items-center justify-center"
+              style={{ color: "var(--t3)", fontSize: "12px" }}
+            >
               No Poster
             </div>
           )}
+
+          <div
+            style={{
+              position: "absolute",
+              top: "10px",
+              right: "10px",
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "4px",
+              padding: "5px 9px",
+              borderRadius: "999px",
+              fontSize: "11px",
+              fontWeight: 700,
+              lineHeight: 1,
+              color: "#FFD84D",
+              background: "rgba(10,10,12,0.82)",
+              border: "1px solid rgba(255,255,255,0.06)",
+              boxShadow: "0 6px 18px rgba(0,0,0,0.24)",
+              zIndex: 2,
+            }}
+          >
+            ★ {rating}
+          </div>
         </div>
 
-        {/* ---------- Film Info ---------- */}
-        <div className="p-3">
-          {/* truncate: cuts off long titles with "..." */}
-          <h3 className="text-white font-semibold text-sm truncate">{title}</h3>
-          <div className="flex items-center gap-2 mt-1">
-            <span className="text-white/50 text-xs">{year}</span>
-            <span className="text-yellow-400 text-xs">★ {rating}</span>
+        <div style={{ padding: "10px 12px 12px" }}>
+          <h3
+            className="truncate"
+            style={{
+              fontSize: "13px",
+              fontWeight: 600,
+              color: "var(--t1)",
+              margin: 0,
+              marginBottom: "6px",
+            }}
+          >
+            {title}
+          </h3>
+
+          <div className="flex items-center gap-2">
+            <span style={{ fontSize: "11px", color: "var(--t3)" }}>{year}</span>
           </div>
-          {/* line-clamp-2: shows max 2 lines of overview text */}
-          <p className="text-white/40 text-xs mt-2 line-clamp-2">{overview}</p>
+
+          <p
+            className="line-clamp-2"
+            style={{
+              fontSize: "11px",
+              color: "var(--t2)",
+              marginTop: "6px",
+              lineHeight: "1.5",
+            }}
+          >
+            {overview}
+          </p>
         </div>
       </div>
     </Link>

--- a/components/film/FilmGrid.tsx
+++ b/components/film/FilmGrid.tsx
@@ -14,33 +14,23 @@
 import FilmCard from "./FilmCard";
 import type { Film } from "@/lib/types";
 
-// ---------- Props ----------
-// The parent passes in the array of films.
-// Film type is imported from lib/types.ts (our shared types file)
 interface FilmGridProps {
   films: Film[];
+  accentBase?: string;
 }
 
-export default function FilmGrid({ films }: FilmGridProps) {
-  // If no films match the mood, show a message instead of an empty grid
+export default function FilmGrid({ films, accentBase }: FilmGridProps) {
   if (films.length === 0) {
     return (
-      <p className="text-center text-white/50 py-12">
+      <p className="text-center py-12 text-t-2">
         No films found. Try a different mood!
       </p>
     );
   }
 
   return (
-    // Tailwind responsive grid:
-    // grid-cols-2 → 2 columns on mobile
-    // sm:grid-cols-3 → 3 columns on screens ≥640px
-    // lg:grid-cols-4 → 4 columns on screens ≥1024px
-    // gap-4 → spacing between cards
-    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
+    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 gap-4 sm:gap-5 lg:gap-6">
       {films.map((film) => (
-        // For each film, render a FilmCard.
-        // We map TMDB's snake_case fields to FilmCard's camelCase props.
         <FilmCard
           key={film.id}
           id={film.id}
@@ -49,6 +39,7 @@ export default function FilmGrid({ films }: FilmGridProps) {
           releaseDate={film.release_date}
           voteAverage={film.vote_average}
           overview={film.overview}
+          accentBase={accentBase}
         />
       ))}
     </div>


### PR DESCRIPTION
- aligned the results page width and spacing with the dashboard layout
- reduced the gap between the navbar and results hero
- fixed mood label styling so selected moods render with their correct accent colors on the results page
- improved the results hero presentation and overall spacing
refined the film grid layout with smoother responsive breakpoints and a max of 6 columns
- updated film cards so the rating sits in the top-right corner of the poster for clearer scanning
- cleaned up results-page state handling so selected moods come from the URL consistently