### PR TITLE
feat: add group swipe page with deck UI, gestures, and responsive layout

### DIFF
--- a/app/api/group/[code]/mood/route.ts
+++ b/app/api/group/[code]/mood/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin, getAuthUser } from "@/lib/supabase-server";
 import { isSessionExpired } from "@/lib/group";
 import { moodMap, buildTMDBParams } from "@/lib/moodMap";
-import type { Film } from "@/lib/types";
+import type { DeckFilm } from "@/lib/types";
 
 const DECK_SIZE = 15;
 
@@ -168,11 +168,23 @@ export async function POST(
   }
 }
 
+// TMDB discover result shape — includes genre_ids which we now capture
+interface TMDBDiscoverResult {
+  id: number;
+  title: string;
+  poster_path: string | null;
+  release_date: string;
+  vote_average: number;
+  overview: string;
+  genre_ids: number[];
+}
+
 // Aggregate all participants' moods with weighted frequency,
 // fetch films from TMDB, and build a balanced deck.
+// Each film is tagged with genre_ids and the mood(s) it was sourced from.
 async function buildSharedDeck(
   participants: { mood_selections: string[] | null }[],
-): Promise<Film[]> {
+): Promise<DeckFilm[]> {
   const apiKey = process.env.TMDB_API_KEY;
   if (!apiKey) throw new Error("TMDB API key not configured");
 
@@ -229,45 +241,75 @@ async function buildSharedDeck(
 
     const res = await fetch(url.toString());
     const data = await res.json();
-    const results: Film[] = (data.results ?? []).map(
-      (r: { id: number; title: string; poster_path: string | null; release_date: string; vote_average: number; overview: string }) => ({
+    const results: (DeckFilm & { _raw_genre_ids: number[] })[] =
+      (data.results ?? []).map((r: TMDBDiscoverResult) => ({
         id: r.id,
         title: r.title,
         poster_path: r.poster_path,
         release_date: r.release_date,
         vote_average: r.vote_average,
         overview: r.overview,
-      }),
-    );
+        genre_ids: r.genre_ids ?? [],
+        mood_keys: [mood],
+        _raw_genre_ids: r.genre_ids ?? [],
+      }));
 
     return { mood, count, results };
   });
 
   const moodResults = await Promise.all(fetchResults);
 
-  // Build deck: pick films per mood allocation, dedup across moods
-  const seen = new Set<number>();
-  const deck: Film[] = [];
+  // Build deck: pick films per mood allocation, dedup across moods.
+  // If a film appears under multiple moods, merge the mood_keys.
+  const seen = new Map<number, DeckFilm>();
+  const deck: DeckFilm[] = [];
 
-  for (const { count, results } of moodResults) {
+  for (const { mood, count, results } of moodResults) {
     let picked = 0;
     for (const film of results) {
       if (picked >= count) break;
-      if (seen.has(film.id)) continue;
-      seen.add(film.id);
-      deck.push(film);
+      const existing = seen.get(film.id);
+      if (existing) {
+        // Film already in deck from another mood — add this mood tag
+        if (!existing.mood_keys.includes(mood)) {
+          existing.mood_keys.push(mood);
+        }
+        continue;
+      }
+      const deckFilm: DeckFilm = {
+        id: film.id,
+        title: film.title,
+        poster_path: film.poster_path,
+        release_date: film.release_date,
+        vote_average: film.vote_average,
+        overview: film.overview,
+        genre_ids: film.genre_ids,
+        mood_keys: [mood],
+      };
+      seen.set(film.id, deckFilm);
+      deck.push(deckFilm);
       picked++;
     }
   }
 
   // If any mood couldn't fill its allocation, backfill from others
   if (deck.length < DECK_SIZE) {
-    for (const { results } of moodResults) {
+    for (const { mood, results } of moodResults) {
       for (const film of results) {
         if (deck.length >= DECK_SIZE) break;
         if (seen.has(film.id)) continue;
-        seen.add(film.id);
-        deck.push(film);
+        const deckFilm: DeckFilm = {
+          id: film.id,
+          title: film.title,
+          poster_path: film.poster_path,
+          release_date: film.release_date,
+          vote_average: film.vote_average,
+          overview: film.overview,
+          genre_ids: film.genre_ids,
+          mood_keys: [mood],
+        };
+        seen.set(film.id, deckFilm);
+        deck.push(deckFilm);
       }
     }
   }

--- a/app/api/group/[code]/swipe/route.ts
+++ b/app/api/group/[code]/swipe/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin, getAuthUser } from "@/lib/supabase-server";
 import { isSessionExpired } from "@/lib/group";
-import type { Film, SwipeVote } from "@/lib/types";
+import type { DeckFilm, SwipeVote } from "@/lib/types";
 
 const VALID_VOTES: SwipeVote[] = ["yes", "no", "maybe"];
 
@@ -88,7 +88,7 @@ export async function GET(
       .select("id, nickname, has_swiped")
       .eq("session_id", session.id);
 
-    const deck: Film[] = session.movie_deck ?? [];
+    const deck: DeckFilm[] = session.movie_deck ?? [];
     const votedIds = new Set((swipes ?? []).map((s) => s.movie_id));
 
     return NextResponse.json({
@@ -185,7 +185,7 @@ export async function POST(
     }
 
     // Validate movie exists in the deck
-    const deck: Film[] = session.movie_deck ?? [];
+    const deck: DeckFilm[] = session.movie_deck ?? [];
     const movieExists = deck.some((film) => film.id === movieId);
 
     if (!movieExists) {

--- a/app/globals.css
+++ b/app/globals.css
@@ -311,3 +311,13 @@
     flex-direction: column;
   }
 }
+
+/* ═══════════════════════════════════════════════════════════
+   Swipe — Responsive overrides
+   ═══════════════════════════════════════════════════════════ */
+
+/* Hide keyboard hints and group dots on mobile */
+@media (max-width: 600px) {
+  .swipe-group-dots { display: none !important; }
+  .swipe-key-hints { display: none !important; }
+}

--- a/app/group/[code]/swipe/page.tsx
+++ b/app/group/[code]/swipe/page.tsx
@@ -1,0 +1,632 @@
+"use client";
+
+import { useEffect, useState, useRef, useCallback } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { useAuth } from "@/components/AuthProvider";
+import { supabase } from "@/lib/supabase";
+import SwipeDeck from "@/components/group/SwipeDeck";
+import type { DeckFilm, SwipeVote } from "@/lib/types";
+
+const AVATAR_COLORS = [
+  { bg: "var(--gold)", text: "#0a0a0c" },
+  { bg: "var(--teal)", text: "#0a0a0c" },
+  { bg: "var(--rose)", text: "#fff" },
+  { bg: "var(--blue)", text: "#fff" },
+  { bg: "var(--violet)", text: "#fff" },
+];
+
+interface ParticipantStatus {
+  id: string;
+  nickname: string;
+  has_swiped: boolean;
+}
+
+export default function GroupSwipePage() {
+  const params = useParams<{ code: string }>();
+  const code = params.code;
+  const router = useRouter();
+  const { user, session: authSession, loading: authLoading } = useAuth();
+
+  const [deck, setDeck] = useState<DeckFilm[]>([]);
+  const [startIndex, setStartIndex] = useState(0);
+  const [participants, setParticipants] = useState<ParticipantStatus[]>([]);
+  const [, setSessionStatus] = useState<string>("swiping");
+  const [myVotes, setMyVotes] = useState<Record<string, SwipeVote>>({});
+  const [isDone, setIsDone] = useState(false);
+  const [allDone, setAllDone] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [participantId, setParticipantId] = useState<string | null>(null);
+  const fetchRef = useRef<() => Promise<void>>(undefined);
+  const redirectingRef = useRef(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("participantId");
+    if (stored) setParticipantId(stored);
+  }, []);
+
+  const getHeaders = useCallback(() => {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    if (authSession?.access_token) {
+      headers.Authorization = `Bearer ${authSession.access_token}`;
+    }
+    return headers;
+  }, [authSession]);
+
+  const fetchSwipeState = useCallback(async () => {
+    if (redirectingRef.current) return;
+
+    try {
+      const pidParam =
+        !authSession?.access_token && participantId
+          ? `?participantId=${participantId}`
+          : "";
+
+      const res = await fetch(`/api/group/${code}/swipe${pidParam}`, {
+        headers: getHeaders(),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        if (data.error === "Session is not in swiping phase") {
+          const lobbyRes = await fetch(`/api/group/${code}`);
+          const lobbyData = await lobbyRes.json();
+          if (lobbyData.session?.status === "done") {
+            redirectingRef.current = true;
+            router.replace(`/group/${code}/results`);
+            return;
+          }
+          if (lobbyData.session?.status === "lobby") {
+            redirectingRef.current = true;
+            router.replace(`/group/${code}`);
+            return;
+          }
+          if (lobbyData.session?.status === "mood") {
+            redirectingRef.current = true;
+            router.replace(`/group/${code}/mood`);
+            return;
+          }
+        }
+        setError(data.error || "Failed to load session");
+        return;
+      }
+
+      const data = await res.json();
+
+      if (data.deck?.length > 0 && !sessionId) {
+        const lobbyRes = await fetch(`/api/group/${code}`);
+        const lobbyData = await lobbyRes.json();
+        if (lobbyData.session?.id) {
+          setSessionId(lobbyData.session.id);
+        }
+      }
+
+      setDeck(data.deck);
+      setParticipants(data.participants);
+      setSessionStatus(data.sessionStatus);
+
+      const voteMap: Record<string, SwipeVote> = {};
+      for (const s of data.swipes) {
+        voteMap[String(s.movie_id)] = s.vote;
+      }
+      setMyVotes(voteMap);
+      setStartIndex(data.progress.swiped);
+
+      const currentPid = participantId;
+      const me = data.participants.find((p: ParticipantStatus) => {
+        if (user) return true;
+        return p.id === currentPid;
+      });
+      if (me?.has_swiped || data.progress.swiped >= data.progress.total) {
+        setIsDone(true);
+      }
+
+      const everyoneDone = data.participants.every(
+        (p: ParticipantStatus) => p.has_swiped,
+      );
+      setAllDone(everyoneDone);
+
+      if (data.sessionStatus === "done") {
+        setAllDone(true);
+        setIsDone(true);
+      }
+    } catch {
+      setError("Something went wrong");
+    } finally {
+      setLoading(false);
+    }
+  }, [code, router, user, participantId, authSession, sessionId, getHeaders]);
+
+  fetchRef.current = fetchSwipeState;
+
+  useEffect(() => {
+    if (!authLoading) fetchSwipeState();
+  }, [authLoading, fetchSwipeState]);
+
+  useEffect(() => {
+    if (loading) return;
+    const interval = setInterval(() => {
+      fetchRef.current?.();
+    }, 2000);
+    return () => clearInterval(interval);
+  }, [loading]);
+
+  useEffect(() => {
+    if (!sessionId) return;
+
+    const participantsChannel = supabase
+      .channel(`swipe-participants-${sessionId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "UPDATE",
+          schema: "public",
+          table: "session_participants",
+          filter: `session_id=eq.${sessionId}`,
+        },
+        () => { fetchRef.current?.(); },
+      )
+      .subscribe();
+
+    const sessionChannel = supabase
+      .channel(`swipe-session-${sessionId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "UPDATE",
+          schema: "public",
+          table: "sessions",
+          filter: `id=eq.${sessionId}`,
+        },
+        () => { fetchRef.current?.(); },
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(participantsChannel);
+      supabase.removeChannel(sessionChannel);
+    };
+  }, [sessionId]);
+
+  const handleVote = useCallback(
+    async (movieId: number, vote: SwipeVote) => {
+      setMyVotes((prev) => ({ ...prev, [String(movieId)]: vote }));
+
+      try {
+        const body: { movieId: number; vote: SwipeVote; participantId?: string } = {
+          movieId,
+          vote,
+        };
+        if (!authSession?.access_token && participantId) {
+          body.participantId = participantId;
+        }
+
+        const res = await fetch(`/api/group/${code}/swipe`, {
+          method: "POST",
+          headers: getHeaders(),
+          body: JSON.stringify(body),
+        });
+
+        const data = await res.json();
+
+        if (!res.ok) {
+          setMyVotes((prev) => {
+            const next = { ...prev };
+            delete next[String(movieId)];
+            return next;
+          });
+          return;
+        }
+
+        if (data.participantDone) setIsDone(true);
+        if (data.allDone) setAllDone(true);
+      } catch {
+        setMyVotes((prev) => {
+          const next = { ...prev };
+          delete next[String(movieId)];
+          return next;
+        });
+      }
+    },
+    [code, authSession, participantId, getHeaders],
+  );
+
+  const voteCounts = Object.values(myVotes).reduce(
+    (acc, v) => {
+      acc[v]++;
+      return acc;
+    },
+    { yes: 0, no: 0, maybe: 0 } as Record<SwipeVote, number>,
+  );
+
+  const finishedCount = participants.filter((p) => p.has_swiped).length;
+  const totalParticipants = participants.length;
+  const swiped = Object.keys(myVotes).length;
+  const totalCards = deck.length;
+  const progressPercent = totalCards > 0 ? (swiped / totalCards) * 100 : 0;
+
+  // Loading
+  if (loading || authLoading) {
+    return (
+      <main
+        className="lobby-grain min-h-screen font-sans"
+        style={{ background: "var(--bg)", color: "var(--t1)" }}
+      >
+        <div className="lobby-ambient" />
+        <div
+          className="flex flex-col items-center justify-center gap-3"
+          style={{ minHeight: "60vh", position: "relative", zIndex: 2 }}
+        >
+          <div
+            style={{
+              width: "6px",
+              height: "6px",
+              borderRadius: "50%",
+              background: "var(--gold)",
+              animation: "breathe 2s ease-in-out infinite",
+            }}
+          />
+          <p className="font-sans" style={{ fontSize: "13px", color: "var(--t3)", fontWeight: 500 }}>
+            Loading deck...
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  // Error
+  if (error && deck.length === 0) {
+    return (
+      <main
+        className="lobby-grain min-h-screen font-sans"
+        style={{ background: "var(--bg)", color: "var(--t1)" }}
+      >
+        <div className="lobby-ambient" />
+        <div
+          className="flex flex-col items-center justify-center gap-4"
+          style={{ minHeight: "60vh", position: "relative", zIndex: 2 }}
+        >
+          <p style={{ fontSize: "14px", color: "var(--rose)" }}>{error}</p>
+          <button
+            onClick={() => router.push(`/group/${code}`)}
+            className="cursor-pointer font-sans"
+            style={{
+              padding: "10px 24px",
+              borderRadius: "var(--r)",
+              background: "none",
+              color: "var(--t2)",
+              fontSize: "13px",
+              fontWeight: 500,
+              border: "1px solid var(--border)",
+            }}
+          >
+            Back to lobby
+          </button>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main
+      className="lobby-grain min-h-screen font-sans"
+      style={{
+        background: "var(--bg)",
+        color: "var(--t1)",
+        position: "relative",
+        overflow: "hidden",
+      }}
+    >
+      <div className="lobby-ambient" />
+
+      {/* Progress strip */}
+      <div
+        className="lobby-section-1"
+        style={{
+          padding: "12px 28px",
+          display: "flex",
+          alignItems: "center",
+          gap: "16px",
+          borderBottom: "1px solid var(--border)",
+          position: "relative",
+          zIndex: 2,
+        }}
+      >
+        <div className="font-sans" style={{ fontSize: "13px", color: "var(--t2)", whiteSpace: "nowrap" }}>
+          Film <strong style={{ color: "var(--t1)", fontWeight: 700 }}>{Math.min(swiped + 1, totalCards)}</strong> of{" "}
+          <strong style={{ color: "var(--t1)", fontWeight: 700 }}>{totalCards}</strong>
+        </div>
+        <div
+          style={{
+            flex: 1,
+            height: "3px",
+            background: "var(--surface3)",
+            borderRadius: "2px",
+            overflow: "hidden",
+          }}
+        >
+          <div
+            style={{
+              height: "100%",
+              background: "var(--gold)",
+              borderRadius: "2px",
+              transition: "width 0.5s cubic-bezier(0.4,0,0.2,1)",
+              width: `${progressPercent}%`,
+            }}
+          />
+        </div>
+        <div className="font-sans" style={{ fontSize: "11px", color: "var(--t3)", whiteSpace: "nowrap" }}>
+          {totalCards - swiped} left
+        </div>
+
+        {/* Group participant dots */}
+        <div
+          className="swipe-group-dots"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "3px",
+            marginLeft: "auto",
+          }}
+        >
+          {participants.map((p, i) => {
+            const color = AVATAR_COLORS[i % AVATAR_COLORS.length];
+            const initial = p.nickname?.[0]?.toUpperCase() || "?";
+            return (
+              <div
+                key={p.id}
+                title={`${p.nickname}${p.has_swiped ? " (done)" : ""}`}
+                style={{
+                  width: "18px",
+                  height: "18px",
+                  borderRadius: "50%",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  fontSize: "7px",
+                  fontWeight: 700,
+                  fontFamily: "var(--sans)",
+                  background: color.bg,
+                  color: color.text,
+                  opacity: p.has_swiped ? 0.35 : 1,
+                  transition: "opacity 0.3s",
+                }}
+              >
+                {initial}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Main card area */}
+      <div
+        className="lobby-section-2"
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          padding: "24px 20px 32px",
+          maxWidth: "820px",
+          width: "100%",
+          margin: "0 auto",
+          position: "relative",
+          zIndex: 2,
+        }}
+      >
+        {!isDone ? (
+          <SwipeDeck
+            deck={deck}
+            startIndex={startIndex}
+            onVote={handleVote}
+            disabled={isDone}
+          />
+        ) : (
+          /* Done state */
+          <div
+            style={{
+              textAlign: "center",
+              animation: "fadeUp 0.5s ease both",
+              padding: "40px 20px",
+            }}
+          >
+            <div
+              style={{
+                width: "56px",
+                height: "56px",
+                borderRadius: "50%",
+                background: "var(--teal-soft)",
+                border: "1.5px solid rgba(90,170,143,0.25)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                margin: "0 auto 20px",
+              }}
+            >
+              <svg
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="var(--teal)"
+                strokeWidth="2.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M5 12.5l5.5 5.5 8.5-8.5" />
+              </svg>
+            </div>
+
+            <h2 className="font-serif" style={{
+              fontSize: "22px",
+              fontWeight: 600,
+              color: "var(--t1)",
+              marginBottom: "6px",
+            }}>
+              All films rated
+            </h2>
+            <p className="font-sans" style={{
+              fontSize: "13px",
+              color: "var(--t2)",
+              lineHeight: 1.6,
+              marginBottom: "20px",
+            }}>
+              Here&apos;s how you voted on the {totalCards}-film deck.
+            </p>
+
+            {/* Vote summary */}
+            <div style={{
+              display: "flex",
+              justifyContent: "center",
+              gap: "28px",
+              marginBottom: "28px",
+            }}>
+              {[
+                { label: "Yes", count: voteCounts.yes, color: "var(--teal)" },
+                { label: "Maybe", count: voteCounts.maybe, color: "var(--gold)" },
+                { label: "No", count: voteCounts.no, color: "var(--rose)" },
+              ].map((item) => (
+                <div key={item.label} style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: "4px" }}>
+                  <span className="font-sans" style={{ fontSize: "28px", fontWeight: 800, lineHeight: 1, color: item.color }}>
+                    {item.count}
+                  </span>
+                  <span className="font-sans" style={{
+                    fontSize: "10px",
+                    fontWeight: 500,
+                    textTransform: "uppercase",
+                    letterSpacing: "0.5px",
+                    color: "var(--t3)",
+                  }}>
+                    {item.label}
+                  </span>
+                </div>
+              ))}
+            </div>
+
+            {/* Waiting or results */}
+            {!allDone ? (
+              <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: "12px" }}>
+                <div className="font-sans" style={{ fontSize: "13px", fontWeight: 600, color: "var(--t2)" }}>
+                  {finishedCount} of {totalParticipants} finished
+                </div>
+                <div className="font-sans" style={{
+                  fontSize: "12px",
+                  color: "var(--t3)",
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "6px",
+                }}>
+                  Waiting for others
+                  <span style={{ display: "inline-flex", gap: "3px" }}>
+                    {[0, 1, 2].map((i) => (
+                      <span
+                        key={i}
+                        style={{
+                          width: "3px",
+                          height: "3px",
+                          borderRadius: "50%",
+                          background: "var(--t3)",
+                          animation: "breathe 1.4s ease-in-out infinite",
+                          animationDelay: `${i * 0.2}s`,
+                        }}
+                      />
+                    ))}
+                  </span>
+                </div>
+
+                {/* Participant status */}
+                <div style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: "6px",
+                  width: "100%",
+                  maxWidth: "260px",
+                  marginTop: "4px",
+                }}>
+                  {participants.map((p) => (
+                    <div
+                      key={p.id}
+                      className="font-sans"
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "space-between",
+                        padding: "8px 12px",
+                        borderRadius: "8px",
+                        background: p.has_swiped ? "var(--teal-soft)" : "var(--surface2)",
+                        border: `1px solid ${p.has_swiped ? "rgba(90,170,143,0.15)" : "var(--border)"}`,
+                        transition: "all 0.3s ease",
+                      }}
+                    >
+                      <span style={{
+                        fontSize: "13px",
+                        fontWeight: 500,
+                        color: p.has_swiped ? "var(--t1)" : "var(--t3)",
+                      }}>
+                        {p.nickname}
+                      </span>
+                      {p.has_swiped ? (
+                        <span style={{ fontSize: "11px", fontWeight: 600, color: "var(--teal)" }}>
+                          Done
+                        </span>
+                      ) : (
+                        <span style={{
+                          width: "6px",
+                          height: "6px",
+                          borderRadius: "50%",
+                          background: "var(--t3)",
+                          animation: "breathe 2s ease-in-out infinite",
+                          display: "inline-block",
+                        }} />
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ) : (
+              <button
+                className="font-sans cursor-pointer"
+                onClick={() => router.push(`/group/${code}/results`)}
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: "8px",
+                  padding: "14px 32px",
+                  borderRadius: "10px",
+                  background: "var(--gold)",
+                  border: "none",
+                  fontSize: "14px",
+                  fontWeight: 600,
+                  color: "#0a0a0c",
+                  transition: "all 0.25s",
+                  animation: "fadeUp 0.4s ease both 0.2s",
+                }}
+              >
+                See group results &rarr;
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Session footer */}
+      <p
+        className="lobby-section-4 font-sans text-center"
+        style={{
+          fontSize: "11px",
+          color: "var(--t3)",
+          padding: "0 0 24px",
+          position: "relative",
+          zIndex: 2,
+        }}
+      >
+        Session {code}
+      </p>
+    </main>
+  );
+}

--- a/components/group/SwipeCard.tsx
+++ b/components/group/SwipeCard.tsx
@@ -1,0 +1,331 @@
+"use client";
+
+import type { DeckFilm } from "@/lib/types";
+import { moodMap } from "@/lib/moodMap";
+import { genreMap } from "@/lib/genres";
+import { useMediaQuery } from "@/lib/useMediaQuery";
+
+interface SwipeCardProps {
+  film: DeckFilm;
+  index: number;
+  total: number;
+  exitDirection: "left" | "right" | "up" | null;
+  dragOffset: { x: number; y: number };
+  isDragging: boolean;
+  onPointerDown: (e: React.PointerEvent) => void;
+  onPointerMove: (e: React.PointerEvent) => void;
+  onPointerUp: () => void;
+}
+
+// Accent color → CSS variable triplet
+const accentVars: Record<string, { color: string; bg: string; border: string }> = {
+  gold:   { color: "var(--gold)",   bg: "var(--gold-soft)",   border: "rgba(196,163,90,0.25)" },
+  blue:   { color: "var(--blue)",   bg: "var(--blue-soft)",   border: "rgba(91,143,212,0.25)" },
+  rose:   { color: "var(--rose)",   bg: "var(--rose-soft)",   border: "rgba(196,107,124,0.25)" },
+  violet: { color: "var(--violet)", bg: "var(--violet-soft)", border: "rgba(139,108,196,0.25)" },
+  teal:   { color: "var(--teal)",   bg: "var(--teal-soft)",   border: "rgba(90,170,143,0.25)" },
+  ember:  { color: "var(--ember)",  bg: "var(--ember-soft)",  border: "rgba(212,122,74,0.25)" },
+};
+
+// Exit transforms keyed by direction
+const EXIT_TRANSFORMS: Record<string, string> = {
+  left: "translateX(-120%) rotate(-8deg)",
+  right: "translateX(120%) rotate(8deg)",
+  up: "translateY(-80%) scale(0.92)",
+};
+
+export default function SwipeCard({
+  film,
+  index,
+  total,
+  exitDirection,
+  dragOffset,
+  isDragging,
+  onPointerDown,
+  onPointerMove,
+  onPointerUp,
+}: SwipeCardProps) {
+  const isMobile = useMediaQuery("(max-width: 600px)");
+  const isTablet = useMediaQuery("(max-width: 900px)");
+
+  const year = film.release_date?.split("-")[0] || "";
+  const rating = film.vote_average?.toFixed(1) || "---";
+  const posterUrl = film.poster_path
+    ? `https://image.tmdb.org/t/p/w500${film.poster_path}`
+    : null;
+
+  // Drag visual feedback
+  const rotation = isDragging ? dragOffset.x * 0.04 : 0;
+  const dragX = isDragging ? dragOffset.x : 0;
+  const dragY = isDragging ? Math.min(dragOffset.y, 0) * 0.3 : 0;
+
+  // Directional color glow while dragging
+  let glowColor = "transparent";
+  let glowLabel = "";
+  if (isDragging) {
+    if (dragOffset.x > 40) {
+      glowColor = "rgba(90,170,143,0.25)";
+      glowLabel = "Yes";
+    } else if (dragOffset.x < -40) {
+      glowColor = "rgba(196,107,124,0.25)";
+      glowLabel = "Nah";
+    } else if (dragOffset.y < -40) {
+      glowColor = "rgba(196,163,90,0.25)";
+      glowLabel = "Maybe";
+    }
+  }
+
+  const isExiting = !!exitDirection;
+
+  // Resolve mood tags from mood_keys
+  const moodTags = (film.mood_keys ?? [])
+    .map((key) => {
+      const config = moodMap[key];
+      if (!config) return null;
+      return { label: config.tagLabel, accent: config.accentColor };
+    })
+    .filter(Boolean) as { label: string; accent: string }[];
+
+  // Resolve genre names from genre_ids (max 3 to keep it clean)
+  const genres = (film.genre_ids ?? [])
+    .map((id) => genreMap[id])
+    .filter(Boolean)
+    .slice(0, 3);
+
+  // Always side-by-side — just adjust poster width per breakpoint
+  const posterWidth = isMobile ? "120px" : isTablet ? "180px" : "240px";
+  const infoPad = isMobile ? "14px 16px" : "24px 28px";
+  const titleSize = isMobile ? "18px" : "24px";
+  const overviewClamp = isMobile ? 3 : 4;
+  const overviewSize = isMobile ? "12px" : "13px";
+  const posterMinH = isMobile ? "240px" : isTablet ? "300px" : "360px";
+
+  return (
+    <div
+      style={{
+        position: "relative",
+        zIndex: 3,
+        background: "var(--surface2)",
+        border: "1px solid var(--border-active)",
+        borderRadius: "16px",
+        boxShadow:
+          "0 8px 32px rgba(0,0,0,0.35), 0 2px 8px rgba(0,0,0,0.2)",
+        overflow: "hidden",
+        display: "grid",
+        gridTemplateColumns: `${posterWidth} 1fr`,
+        userSelect: "none",
+        transform: isExiting
+          ? EXIT_TRANSFORMS[exitDirection!]
+          : `translate(${dragX}px, ${dragY}px) rotate(${rotation}deg)`,
+        opacity: isExiting ? 0 : 1,
+        transition: isDragging
+          ? "none"
+          : isExiting
+            ? "transform 0.4s cubic-bezier(0.4,0,0.2,1), opacity 0.35s ease"
+            : "transform 0.25s ease",
+        cursor: isDragging ? "grabbing" : "grab",
+        touchAction: "none",
+      }}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerUp}
+    >
+      {/* Directional glow overlay */}
+      {isDragging && glowLabel && (
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            zIndex: 10,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            borderRadius: "16px",
+            pointerEvents: "none",
+            background: glowColor,
+            transition: "background 0.15s ease",
+          }}
+        >
+          <span
+            className="font-sans"
+            style={{
+              fontSize: "28px",
+              fontWeight: 800,
+              letterSpacing: "2px",
+              textTransform: "uppercase",
+              color:
+                glowLabel === "Yes"
+                  ? "var(--teal)"
+                  : glowLabel === "Nah"
+                    ? "var(--rose)"
+                    : "var(--gold)",
+              opacity: Math.min(
+                1,
+                Math.max(Math.abs(dragOffset.x), Math.abs(dragOffset.y)) / 100,
+              ),
+            }}
+          >
+            {glowLabel}
+          </span>
+        </div>
+      )}
+
+      {/* Poster */}
+      <div
+        style={{
+          position: "relative",
+          width: "100%",
+          minHeight: posterMinH,
+          backgroundImage: posterUrl
+            ? `url(${posterUrl})`
+            : "linear-gradient(160deg, #1a1520, #2a1f35 30%, #0d1520)",
+          backgroundSize: "cover",
+          backgroundPosition: "center top",
+        }}
+      >
+        {/* Counter badge */}
+        <div
+          className="font-sans"
+          style={{
+            position: "absolute",
+            top: "10px",
+            left: "10px",
+            zIndex: 2,
+            padding: "3px 8px",
+            borderRadius: "8px",
+            background: "rgba(0,0,0,0.6)",
+            backdropFilter: "blur(8px)",
+            fontSize: "10px",
+            fontWeight: 600,
+            lineHeight: 1,
+            color: "rgba(255,255,255,0.75)",
+          }}
+        >
+          {index + 1} / {total}
+        </div>
+      </div>
+
+      {/* Info */}
+      <div
+        style={{
+          padding: infoPad,
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          minHeight: 0,
+          overflow: "hidden",
+        }}
+      >
+        <h2
+          className="font-serif"
+          style={{
+            fontSize: titleSize,
+            lineHeight: 1.15,
+            fontWeight: 600,
+            color: "var(--t1)",
+            marginBottom: "6px",
+            letterSpacing: "-0.3px",
+          }}
+        >
+          {film.title}
+        </h2>
+
+        {/* Year + Rating row */}
+        <div
+          className="font-sans"
+          style={{
+            fontSize: "12px",
+            color: "var(--t3)",
+            marginBottom: "10px",
+            display: "flex",
+            alignItems: "center",
+            gap: "10px",
+          }}
+        >
+          {year && <span>{year}</span>}
+          <span
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "4px",
+              color: "var(--gold)",
+              fontWeight: 600,
+            }}
+          >
+            <svg width="11" height="11" viewBox="0 0 12 12" fill="var(--gold)">
+              <path d="M6 .5l1.55 3.6 3.95.5-2.9 2.7.7 3.9L6 9.3 2.7 11.2l.7-3.9L.5 4.6l3.95-.5z" />
+            </svg>
+            {rating}
+          </span>
+        </div>
+
+        {/* Mood pills */}
+        {moodTags.length > 0 && (
+          <div style={{ display: "flex", gap: "5px", flexWrap: "wrap", marginBottom: "6px" }}>
+            {moodTags.map((tag) => {
+              const vars = accentVars[tag.accent] ?? accentVars.gold;
+              return (
+                <span
+                  key={tag.label}
+                  className="font-sans"
+                  style={{
+                    padding: "3px 8px",
+                    borderRadius: "100px",
+                    fontSize: isMobile ? "9px" : "10px",
+                    fontWeight: 600,
+                    lineHeight: 1,
+                    color: vars.color,
+                    background: vars.bg,
+                    border: `1px solid ${vars.border}`,
+                  }}
+                >
+                  {tag.label}
+                </span>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Genre pills */}
+        {genres.length > 0 && (
+          <div style={{ display: "flex", gap: "4px", flexWrap: "wrap", marginBottom: isMobile ? "8px" : "14px" }}>
+            {genres.map((name) => (
+              <span
+                key={name}
+                className="font-sans"
+                style={{
+                  padding: "3px 8px",
+                  borderRadius: "100px",
+                  fontSize: isMobile ? "9px" : "10px",
+                  fontWeight: 500,
+                  lineHeight: 1,
+                  background: "var(--tag-bg)",
+                  border: "1px solid var(--tag-border)",
+                  color: "var(--t2)",
+                }}
+              >
+                {name}
+              </span>
+            ))}
+          </div>
+        )}
+
+        <p
+          className="font-sans"
+          style={{
+            fontSize: overviewSize,
+            lineHeight: 1.5,
+            color: "var(--t2)",
+            display: "-webkit-box",
+            WebkitLineClamp: overviewClamp,
+            WebkitBoxOrient: "vertical",
+            overflow: "hidden",
+          }}
+        >
+          {film.overview}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/components/group/SwipeDeck.tsx
+++ b/components/group/SwipeDeck.tsx
@@ -1,0 +1,319 @@
+"use client";
+
+import { useState, useCallback, useRef, useEffect } from "react";
+import type { DeckFilm, SwipeVote } from "@/lib/types";
+import SwipeCard from "./SwipeCard";
+
+interface SwipeDeckProps {
+  deck: DeckFilm[];
+  startIndex: number;
+  onVote: (movieId: number, vote: SwipeVote) => void;
+  disabled: boolean;
+}
+
+const SWIPE_THRESHOLD = 80;
+const SWIPE_Y_THRESHOLD = 60;
+
+// Vote button config — keeps the JSX clean
+const VOTE_BUTTONS: {
+  vote: SwipeVote;
+  label: string;
+  color: string;
+  hoverBg: string;
+  hoverText: string;
+  size: number;
+  icon: React.ReactNode;
+}[] = [
+  {
+    vote: "no",
+    label: "Nah",
+    color: "var(--rose)",
+    hoverBg: "var(--rose)",
+    hoverText: "#fff",
+    size: 56,
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+        <path d="M5 5l10 10M15 5L5 15" />
+      </svg>
+    ),
+  },
+  {
+    vote: "maybe",
+    label: "Maybe",
+    color: "var(--gold)",
+    hoverBg: "var(--gold)",
+    hoverText: "#0a0a0c",
+    size: 46,
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+        <path d="M4 10.5c2-3 4-3 6 0s4 3 6 0" />
+      </svg>
+    ),
+  },
+  {
+    vote: "yes",
+    label: "Yes",
+    color: "var(--teal)",
+    hoverBg: "var(--teal)",
+    hoverText: "#0a0a0c",
+    size: 56,
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M4.5 10.5l4 4 7-7" />
+      </svg>
+    ),
+  },
+];
+
+export default function SwipeDeck({
+  deck,
+  startIndex,
+  onVote,
+  disabled,
+}: SwipeDeckProps) {
+  const [currentIndex, setCurrentIndex] = useState(startIndex);
+  const [exitDirection, setExitDirection] = useState<"left" | "right" | "up" | null>(null);
+  const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 });
+  const [isDragging, setIsDragging] = useState(false);
+  const [isVoting, setIsVoting] = useState(false);
+  const [hoveredBtn, setHoveredBtn] = useState<SwipeVote | null>(null);
+  const dragStart = useRef<{ x: number; y: number } | null>(null);
+  const votingRef = useRef(false);
+
+  useEffect(() => {
+    setCurrentIndex(startIndex);
+  }, [startIndex]);
+
+  const triggerVote = useCallback(
+    (vote: SwipeVote) => {
+      if (votingRef.current || disabled || currentIndex >= deck.length) return;
+      votingRef.current = true;
+      setIsVoting(true);
+
+      const direction =
+        vote === "no" ? "left" : vote === "yes" ? "right" : "up";
+      setExitDirection(direction);
+
+      const movieId = deck[currentIndex].id;
+
+      setTimeout(() => {
+        onVote(movieId, vote);
+        setCurrentIndex((prev) => prev + 1);
+        setExitDirection(null);
+        setDragOffset({ x: 0, y: 0 });
+        votingRef.current = false;
+        setIsVoting(false);
+      }, 380);
+    },
+    [currentIndex, deck, disabled, onVote],
+  );
+
+  // Keyboard controls
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "ArrowLeft") triggerVote("no");
+      else if (e.key === "ArrowRight") triggerVote("yes");
+      else if (e.key === "ArrowDown") triggerVote("maybe");
+    };
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [triggerVote]);
+
+  const handlePointerDown = (e: React.PointerEvent) => {
+    if (disabled || votingRef.current) return;
+    dragStart.current = { x: e.clientX, y: e.clientY };
+    setIsDragging(true);
+    (e.target as HTMLElement).setPointerCapture?.(e.pointerId);
+  };
+
+  const handlePointerMove = (e: React.PointerEvent) => {
+    if (!dragStart.current || !isDragging) return;
+    const dx = e.clientX - dragStart.current.x;
+    const dy = e.clientY - dragStart.current.y;
+    setDragOffset({ x: dx, y: dy });
+  };
+
+  const handlePointerUp = () => {
+    if (!isDragging) return;
+    setIsDragging(false);
+
+    if (dragOffset.x > SWIPE_THRESHOLD) {
+      triggerVote("yes");
+    } else if (dragOffset.x < -SWIPE_THRESHOLD) {
+      triggerVote("no");
+    } else if (dragOffset.y < -SWIPE_Y_THRESHOLD) {
+      triggerVote("maybe");
+    } else {
+      setDragOffset({ x: 0, y: 0 });
+    }
+
+    dragStart.current = null;
+  };
+
+  if (currentIndex >= deck.length) return null;
+
+  const currentFilm = deck[currentIndex];
+  const hasNext = currentIndex + 1 < deck.length;
+  const hasNextNext = currentIndex + 2 < deck.length;
+
+  return (
+    <div style={{ width: "100%" }}>
+      {/* Card stack */}
+      <div style={{ position: "relative", width: "100%" }}>
+        {/* Ghost shadow cards */}
+        {hasNextNext && (
+          <div
+            style={{
+              position: "absolute",
+              inset: "5px 8px -5px 8px",
+              borderRadius: "16px",
+              border: "1px solid var(--border-h)",
+              background: "var(--surface2)",
+              pointerEvents: "none",
+              opacity: 0.35,
+              zIndex: 1,
+            }}
+          />
+        )}
+        {hasNext && (
+          <div
+            style={{
+              position: "absolute",
+              inset: "2px 4px -2px 4px",
+              borderRadius: "16px",
+              border: "1px solid var(--border-h)",
+              background: "var(--surface2)",
+              pointerEvents: "none",
+              opacity: 0.6,
+              zIndex: 2,
+            }}
+          />
+        )}
+
+        <SwipeCard
+          film={currentFilm}
+          index={currentIndex}
+          total={deck.length}
+          exitDirection={exitDirection}
+          dragOffset={dragOffset}
+          isDragging={isDragging}
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+        />
+      </div>
+
+      {/* Vote buttons */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: "24px",
+          padding: "28px 0 8px",
+        }}
+      >
+        {VOTE_BUTTONS.map((btn) => {
+          const isHovered = hoveredBtn === btn.vote;
+          return (
+            <button
+              key={btn.vote}
+              onClick={() => triggerVote(btn.vote)}
+              onMouseEnter={() => setHoveredBtn(btn.vote)}
+              onMouseLeave={() => setHoveredBtn(null)}
+              disabled={disabled || isVoting}
+              aria-label={`Vote ${btn.vote}`}
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                gap: "6px",
+                cursor: disabled || isVoting ? "default" : "pointer",
+                background: "none",
+                border: "none",
+                padding: 0,
+                opacity: disabled || isVoting ? 0.4 : 1,
+                transform: isHovered ? "scale(1.08)" : "scale(1)",
+                transition: "transform 0.2s",
+              }}
+            >
+              <span
+                style={{
+                  width: `${btn.size}px`,
+                  height: `${btn.size}px`,
+                  borderRadius: "50%",
+                  border: `2px solid ${btn.color}`,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  color: isHovered ? btn.hoverText : btn.color,
+                  background: isHovered ? btn.hoverBg : "transparent",
+                  transition: "all 0.2s",
+                }}
+              >
+                {btn.icon}
+              </span>
+              <span
+                className="font-sans"
+                style={{
+                  fontSize: "11px",
+                  fontWeight: 500,
+                  color: isHovered ? btn.color : "var(--t3)",
+                  transition: "color 0.2s",
+                }}
+              >
+                {btn.label}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Keyboard hints */}
+      <div
+        className="swipe-key-hints"
+        style={{
+          display: "flex",
+          justifyContent: "center",
+          gap: "28px",
+          padding: "6px 0 0",
+        }}
+      >
+        {[
+          { key: "\u2190", label: "Nah" },
+          { key: "\u2193", label: "Maybe" },
+          { key: "\u2192", label: "Yes" },
+        ].map((h) => (
+          <span
+            key={h.label}
+            className="font-sans"
+            style={{
+              fontSize: "10px",
+              color: "var(--t3)",
+              display: "flex",
+              alignItems: "center",
+              gap: "4px",
+            }}
+          >
+            <kbd
+              style={{
+                padding: "1px 5px",
+                borderRadius: "4px",
+                background: "var(--surface2)",
+                border: "1px solid var(--border)",
+                fontSize: "9px",
+                fontWeight: 600,
+                lineHeight: 1.2,
+                color: "var(--t2)",
+                fontFamily: "var(--sans)",
+              }}
+            >
+              {h.key}
+            </kbd>
+            {h.label}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/lib/genres.ts
+++ b/lib/genres.ts
@@ -1,0 +1,23 @@
+// TMDB genre ID → human-readable name
+// Full list from https://api.themoviedb.org/3/genre/movie/list
+export const genreMap: Record<number, string> = {
+  28: "Action",
+  12: "Adventure",
+  16: "Animation",
+  35: "Comedy",
+  80: "Crime",
+  99: "Documentary",
+  18: "Drama",
+  10751: "Family",
+  14: "Fantasy",
+  36: "History",
+  27: "Horror",
+  10402: "Music",
+  9648: "Mystery",
+  10749: "Romance",
+  878: "Sci-Fi",
+  10770: "TV Movie",
+  53: "Thriller",
+  10752: "War",
+  37: "Western",
+};

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -60,6 +60,14 @@ export interface TrailerData {
   type: string;
 }
 
+// ─── Deck Film (enriched for swipe cards) ────────────
+
+/** A film inside a group session deck — carries genre IDs and the mood(s) it was sourced from */
+export interface DeckFilm extends Film {
+  genre_ids: number[];
+  mood_keys: string[];
+}
+
 // ─── Group Session Types ──────────────────────────────
 
 export type SessionStatus = "lobby" | "mood" | "swiping" | "done";

--- a/lib/useMediaQuery.ts
+++ b/lib/useMediaQuery.ts
@@ -1,0 +1,19 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return window.matchMedia(query).matches;
+  });
+
+  useEffect(() => {
+    const mql = window.matchMedia(query);
+    const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, [query]);
+
+  return matches;
+}


### PR DESCRIPTION

# Swipe and Voting 

## Overview

Implements the full swipe-based voting flow for group sessions, covering backend APIs, frontend UI, and design system integration. Enables participants to vote on a shared movie deck with real-time progress tracking and automatic session completion.

---

## Frontend - Swipe

### Swipe Page (`app/group/[code]/swipe/page.tsx`)
- Manages full swipe flow state
- Fetches deck and existing votes on mount (resume support)
- Optimistic voting with rollback on error
- Realtime subscriptions (`session_participants`, `sessions`) with polling fallback
- Tracks completion and detects session transition to `done`

### Components

- **SwipeDeck**
  - Card stack with depth
  - Gesture handling: drag (yes/no/maybe), keyboard arrows, buttons
  - Smooth voting animation 

- **SwipeCard**
  - Side-by-side poster + info layout across all breakpoints
  - Displays title, year, rating, mood tags, genre pills, and overview
  - Directional drag feedback (color + glow)
  - Poster counter badge

### Supporting

- `DeckFilm` type extends film data with `genre_ids` and `mood_keys`
- Genre mapping utility for readable labels
- `useMediaQuery` hook for responsive behavior

### Done State
- Vote summary (yes / maybe / no)
- Participant progress indicators
- "See group results" when all complete

---