### PR TITLE
feat: unified search by title/actor/director + browse category buttons

### DIFF
--- a/app/api/movies/browse/route.ts
+++ b/app/api/movies/browse/route.ts
@@ -1,0 +1,133 @@
+import { NextRequest, NextResponse } from "next/server";
+
+type FilmRaw = {
+  id: number;
+  title: string;
+  poster_path: string | null;
+  release_date: string;
+  vote_average: number;
+  overview: string;
+};
+
+function mapFilm(f: FilmRaw) {
+  return {
+    id: f.id,
+    title: f.title,
+    poster_path: f.poster_path,
+    release_date: f.release_date,
+    vote_average: f.vote_average,
+    overview: f.overview,
+  };
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const category = searchParams.get("category");
+  const genreId = searchParams.get("genre");
+
+  const apiKey = process.env.TMDB_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: "TMDB API key not configured" },
+      { status: 500 },
+    );
+  }
+
+  if (!category) {
+    return NextResponse.json(
+      { error: "Missing 'category' query parameter" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    let url: URL;
+
+    switch (category) {
+      case "trending": {
+        url = new URL("https://api.themoviedb.org/3/trending/movie/day");
+        url.searchParams.set("api_key", apiKey);
+        url.searchParams.set("language", "en-US");
+        break;
+      }
+      case "top-rated": {
+        url = new URL("https://api.themoviedb.org/3/movie/top_rated");
+        url.searchParams.set("api_key", apiKey);
+        url.searchParams.set("language", "en-US");
+        url.searchParams.set("page", "1");
+        break;
+      }
+      case "new-releases": {
+        url = new URL("https://api.themoviedb.org/3/discover/movie");
+        url.searchParams.set("api_key", apiKey);
+        url.searchParams.set("language", "en-US");
+        url.searchParams.set("sort_by", "release_date.desc");
+        url.searchParams.set("include_adult", "false");
+        url.searchParams.set("include_video", "false");
+        url.searchParams.set("page", "1");
+        url.searchParams.set("vote_count.gte", "10");
+        const today = new Date();
+        const oneYearAgo = new Date(today);
+        oneYearAgo.setFullYear(today.getFullYear() - 1);
+        url.searchParams.set(
+          "primary_release_date.gte",
+          oneYearAgo.toISOString().split("T")[0],
+        );
+        url.searchParams.set(
+          "primary_release_date.lte",
+          today.toISOString().split("T")[0],
+        );
+        break;
+      }
+      case "in-cinemas": {
+        url = new URL("https://api.themoviedb.org/3/movie/now_playing");
+        url.searchParams.set("api_key", apiKey);
+        url.searchParams.set("language", "en-US");
+        url.searchParams.set("page", "1");
+        url.searchParams.set("region", "NO");
+        break;
+      }
+      case "by-genre": {
+        if (!genreId) {
+          return NextResponse.json(
+            { error: "Missing 'genre' query parameter" },
+            { status: 400 },
+          );
+        }
+        url = new URL("https://api.themoviedb.org/3/discover/movie");
+        url.searchParams.set("api_key", apiKey);
+        url.searchParams.set("language", "en-US");
+        url.searchParams.set("with_genres", genreId);
+        url.searchParams.set("sort_by", "popularity.desc");
+        url.searchParams.set("page", "1");
+        break;
+      }
+      case "streaming-norway": {
+        url = new URL("https://api.themoviedb.org/3/discover/movie");
+        url.searchParams.set("api_key", apiKey);
+        url.searchParams.set("language", "en-US");
+        url.searchParams.set("sort_by", "popularity.desc");
+        url.searchParams.set("watch_region", "NO");
+        url.searchParams.set("with_watch_monetization_types", "flatrate");
+        url.searchParams.set("page", "1");
+        break;
+      }
+      default:
+        return NextResponse.json(
+          { error: "Invalid category" },
+          { status: 400 },
+        );
+    }
+
+    const res = await fetch(url.toString());
+    if (!res.ok) throw new Error("Failed to fetch from TMDB");
+    const data = await res.json();
+
+    const films = (data.results ?? []).slice(0, 20).map(mapFilm);
+    return NextResponse.json({ films });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Internal server error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/api/movies/search/route.ts
+++ b/app/api/movies/search/route.ts
@@ -42,7 +42,7 @@ async function searchByTitle(query: string, apiKey: string) {
 async function searchByPerson(
   query: string,
   apiKey: string,
-  role: "actor" | "director"
+  role: "actor" | "director",
 ) {
   // Step 1: find the person
   const personUrl = new URL("https://api.themoviedb.org/3/search/person");
@@ -61,7 +61,7 @@ async function searchByPerson(
 
   // Step 2: fetch their movie credits
   const creditsUrl = new URL(
-    `https://api.themoviedb.org/3/person/${person.id}/movie_credits`
+    `https://api.themoviedb.org/3/person/${person.id}/movie_credits`,
   );
   creditsUrl.searchParams.set("api_key", apiKey);
   creditsUrl.searchParams.set("language", "en-US");
@@ -73,7 +73,10 @@ async function searchByPerson(
   // Step 3: return relevant credits
   if (role === "actor") {
     return (creditsData.cast ?? [])
-      .sort((a: { popularity: number }, b: { popularity: number }) => b.popularity - a.popularity)
+      .sort(
+        (a: { popularity: number }, b: { popularity: number }) =>
+          b.popularity - a.popularity,
+      )
       .slice(0, 20)
       .map(mapFilm);
   }
@@ -81,7 +84,10 @@ async function searchByPerson(
   // director — filter crew by job
   return (creditsData.crew ?? [])
     .filter((c: { job: string }) => c.job === "Director")
-    .sort((a: { popularity: number }, b: { popularity: number }) => b.popularity - a.popularity)
+    .sort(
+      (a: { popularity: number }, b: { popularity: number }) =>
+        b.popularity - a.popularity,
+    )
     .slice(0, 20)
     .map(mapFilm);
 }
@@ -94,7 +100,7 @@ export async function GET(request: NextRequest) {
   if (!query || query.trim() === "") {
     return NextResponse.json(
       { error: "Missing 'query' query parameter" },
-      { status: 400 }
+      { status: 400 },
     );
   }
 
@@ -102,7 +108,7 @@ export async function GET(request: NextRequest) {
   if (!apiKey) {
     return NextResponse.json(
       { error: "TMDB API key not configured" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 
@@ -113,6 +119,20 @@ export async function GET(request: NextRequest) {
       films = await searchByPerson(query.trim(), apiKey, "actor");
     } else if (type === "director") {
       films = await searchByPerson(query.trim(), apiKey, "director");
+    } else if (type === "all") {
+      const [titleFilms, actorFilms, directorFilms] = await Promise.all([
+        searchByTitle(query.trim(), apiKey),
+        searchByPerson(query.trim(), apiKey, "actor"),
+        searchByPerson(query.trim(), apiKey, "director"),
+      ]);
+      const seen = new Set<number>();
+      films = [...titleFilms, ...actorFilms, ...directorFilms]
+        .filter((f: { id: number }) => {
+          if (seen.has(f.id)) return false;
+          seen.add(f.id);
+          return true;
+        })
+        .slice(0, 20);
     } else {
       films = await searchByTitle(query.trim(), apiKey);
     }
@@ -121,7 +141,7 @@ export async function GET(request: NextRequest) {
   } catch {
     return NextResponse.json(
       { error: "Internal server error" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/components/dashboard/SearchBox.tsx
+++ b/components/dashboard/SearchBox.tsx
@@ -3,12 +3,28 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import type { Film } from "@/lib/types";
 
-type SearchType = "title" | "actor" | "director";
+const BROWSE_CATEGORIES = [
+  { id: "trending", label: "Trending" },
+  { id: "top-rated", label: "Top Rated" },
+  { id: "new-releases", label: "New Releases" },
+  { id: "in-cinemas", label: "In Cinemas" },
+  { id: "by-genre", label: "By Genre" },
+  { id: "streaming-norway", label: "Streaming in Norway" },
+] as const;
 
-const browseTags: { label: string; type: SearchType }[] = [
-  { label: "Film Title", type: "title" },
-  { label: "Actor", type: "actor" },
-  { label: "Director", type: "director" },
+type BrowseCategory = (typeof BROWSE_CATEGORIES)[number]["id"];
+
+const GENRES = [
+  { id: 28, label: "Action" },
+  { id: 35, label: "Comedy" },
+  { id: 18, label: "Drama" },
+  { id: 27, label: "Horror" },
+  { id: 878, label: "Sci-Fi" },
+  { id: 10749, label: "Romance" },
+  { id: 53, label: "Thriller" },
+  { id: 16, label: "Animation" },
+  { id: 80, label: "Crime" },
+  { id: 14, label: "Fantasy" },
 ];
 
 // Simple genre lookup for the trending list display
@@ -51,8 +67,11 @@ export default function SearchBox({
   isExpanded,
 }: SearchBoxProps) {
   const [query, setQuery] = useState("");
-  const [searchType, setSearchType] = useState<SearchType>("title");
   const [isLoading, setIsLoading] = useState(false);
+  const [activeCategory, setActiveCategory] = useState<BrowseCategory | null>(
+    null,
+  );
+  const [activeGenre, setActiveGenre] = useState<number | null>(null);
   const [trending, setTrending] = useState<TrendingItem[]>([]);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -65,16 +84,36 @@ export default function SearchBox({
   }, []);
 
   const doSearch = useCallback(
-    async (q: string, type: SearchType) => {
+    async (q: string) => {
       if (!q.trim()) {
         onResults?.([]);
         return;
       }
       setIsLoading(true);
+      setActiveCategory(null);
       try {
         const res = await fetch(
-          `/api/movies/search?query=${encodeURIComponent(q.trim())}&type=${type}`,
+          `/api/movies/search?query=${encodeURIComponent(q.trim())}&type=all`,
         );
+        const data = await res.json();
+        onResults?.(data.films ?? []);
+        onExpand?.();
+      } catch {
+        onResults?.([]);
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [onResults, onExpand],
+  );
+
+  const doBrowse = useCallback(
+    async (category: BrowseCategory, genreId?: number) => {
+      setIsLoading(true);
+      try {
+        const params = new URLSearchParams({ category });
+        if (genreId) params.set("genre", String(genreId));
+        const res = await fetch(`/api/movies/browse?${params.toString()}`);
         const data = await res.json();
         onResults?.(data.films ?? []);
         onExpand?.();
@@ -94,11 +133,39 @@ export default function SearchBox({
       onResults?.([]);
       return;
     }
-    debounceRef.current = setTimeout(() => doSearch(query, searchType), 400);
+    debounceRef.current = setTimeout(() => doSearch(query), 400);
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, [query, searchType]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [query]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleCategoryClick = (categoryId: BrowseCategory) => {
+    if (categoryId === "by-genre") {
+      if (activeCategory === "by-genre") {
+        setActiveCategory(null);
+        setActiveGenre(null);
+        onResults?.([]);
+      } else {
+        setActiveCategory("by-genre");
+        setQuery("");
+      }
+      return;
+    }
+    if (activeCategory === categoryId) {
+      setActiveCategory(null);
+      onResults?.([]);
+      return;
+    }
+    setActiveCategory(categoryId);
+    setQuery("");
+    doBrowse(categoryId);
+  };
+
+  const handleGenreClick = (genreId: number) => {
+    setActiveGenre(genreId);
+    doBrowse("by-genre", genreId);
+  };
+
   return (
     <section
       onClick={onExpand}
@@ -150,6 +217,7 @@ export default function SearchBox({
         Search by film title, actor, or director.
       </p>
 
+      {/* Search Input */}
       <div className="relative mb-3.5" onClick={(e) => e.stopPropagation()}>
         <svg
           className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2"
@@ -168,13 +236,7 @@ export default function SearchBox({
           type="text"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          placeholder={
-            searchType === "actor"
-              ? "Search by actor name..."
-              : searchType === "director"
-                ? "Search by director name..."
-                : "Search for a film..."
-          }
+          placeholder="Film, actor, director..."
           aria-label="Search films, actors, or directors"
           style={{
             width: "100%",
@@ -192,18 +254,22 @@ export default function SearchBox({
         )}
       </div>
 
-      <div className="mb-4.5 flex flex-wrap gap-2" onClick={(e) => e.stopPropagation()}>
-        {browseTags.map((tag) => (
+      {/* Browse category buttons */}
+      <div
+        className="mb-4 flex flex-wrap gap-2"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {BROWSE_CATEGORIES.map((cat) => (
           <button
-            key={tag.type}
+            key={cat.id}
             type="button"
-            onClick={() => setSearchType(tag.type)}
+            onClick={() => handleCategoryClick(cat.id)}
             style={{
               borderRadius: "999px",
-              border: `1px solid ${searchType === tag.type ? "var(--border-active)" : "var(--border)"}`,
+              border: `1px solid ${activeCategory === cat.id ? "var(--border-active)" : "var(--border)"}`,
               background:
-                searchType === tag.type ? "var(--surface2)" : "var(--bg)",
-              color: searchType === tag.type ? "var(--t1)" : "var(--t2)",
+                activeCategory === cat.id ? "var(--surface2)" : "var(--bg)",
+              color: activeCategory === cat.id ? "var(--t1)" : "var(--t2)",
               fontSize: "12px",
               lineHeight: 1,
               padding: "8px 11px",
@@ -211,61 +277,94 @@ export default function SearchBox({
               transition: "all 0.2s",
             }}
           >
-            {tag.label}
+            {cat.label}
           </button>
         ))}
       </div>
 
-      <div>
+      {/* Genre sub-buttons (shown when By Genre is active) */}
+      {activeCategory === "by-genre" && (
         <div
-          style={{
-            color: "var(--t3)",
-            fontSize: "10px",
-            fontWeight: 600,
-            letterSpacing: "1.8px",
-            textTransform: "uppercase",
-            marginBottom: "10px",
-          }}
+          className="mb-4 flex flex-wrap gap-1.5"
+          onClick={(e) => e.stopPropagation()}
         >
-          Trending Today
-        </div>
-
-        <div className="flex flex-col gap-2.5">
-          {trending.map((item, i) => (
-            <div
-              key={item.id}
-              className="grid grid-cols-[auto_1fr_auto] items-center gap-2.5"
+          {GENRES.map((g) => (
+            <button
+              key={g.id}
+              type="button"
+              onClick={() => handleGenreClick(g.id)}
+              style={{
+                borderRadius: "999px",
+                border: `1px solid ${activeGenre === g.id ? "var(--border-active)" : "var(--border)"}`,
+                background:
+                  activeGenre === g.id ? "var(--surface2)" : "var(--bg)",
+                color: activeGenre === g.id ? "var(--t1)" : "var(--t3)",
+                fontSize: "11px",
+                lineHeight: 1,
+                padding: "6px 10px",
+                cursor: "pointer",
+                transition: "all 0.2s",
+              }}
             >
-              <span
-                style={{
-                  color: "var(--t3)",
-                  fontSize: "12px",
-                  fontVariantNumeric: "tabular-nums",
-                }}
-              >
-                {String(i + 1).padStart(2, "0")}
-              </span>
-              <span
-                style={{
-                  color: "var(--t1)",
-                  fontSize: "14px",
-                  fontWeight: 500,
-                }}
-              >
-                {item.title}
-              </span>
-              <span style={{ color: "var(--t3)", fontSize: "12px" }}>
-                {GENRE_MAP[item.genre_ids?.[0]] ?? "Film"}
-              </span>
-            </div>
+              {g.label}
+            </button>
           ))}
-          {trending.length === 0 && (
-            <span style={{ color: "var(--t3)", fontSize: "12px" }}>
-              Loading...
-            </span>
-          )}
         </div>
-      </div>
+      )}
+
+      {/* Trending Today list (shown when no search/browse active) */}
+      {!query && !activeCategory && (
+        <div>
+          <div
+            style={{
+              color: "var(--t3)",
+              fontSize: "10px",
+              fontWeight: 600,
+              letterSpacing: "1.8px",
+              textTransform: "uppercase",
+              marginBottom: "10px",
+            }}
+          >
+            Trending Today
+          </div>
+
+          <div className="flex flex-col gap-2.5">
+            {trending.map((item, i) => (
+              <div
+                key={item.id}
+                className="grid grid-cols-[auto_1fr_auto] items-center gap-2.5"
+              >
+                <span
+                  style={{
+                    color: "var(--t3)",
+                    fontSize: "12px",
+                    fontVariantNumeric: "tabular-nums",
+                  }}
+                >
+                  {String(i + 1).padStart(2, "0")}
+                </span>
+                <span
+                  style={{
+                    color: "var(--t1)",
+                    fontSize: "14px",
+                    fontWeight: 500,
+                  }}
+                >
+                  {item.title}
+                </span>
+                <span style={{ color: "var(--t3)", fontSize: "12px" }}>
+                  {GENRE_MAP[item.genre_ids?.[0]] ?? "Film"}
+                </span>
+              </div>
+            ))}
+            {trending.length === 0 && (
+              <span style={{ color: "var(--t3)", fontSize: "12px" }}>
+                Loading...
+              </span>
+            )}
+          </div>
+        </div>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
Added six browse category pills below the input:
- Trending (TMDB trending/day)
- Top Rated (TMDB movie/top_rated)
- New Releases (discover sorted by release date, last 12 months)
- In Cinemas (TMDB now_playing, region: NO)
- By Genre (discover with genre filter, expands sub-genre chips)
- Streaming in Norway (discover filtered by flatrate watch providers, region: NO)

New /api/movies/browse route handles all category fetches.
search route extended with type=all for combined parallel search.
