### PR TITLE
fix: navbar profile link and avatar linking to profile page

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -137,20 +137,22 @@ export default function Navbar() {
             </Link>
 
             <div> {/* avatar */}</div>
-            <div
-              className="flex items-center justify-center"
-              style={{
-                width: "32px",
-                height: "32px",
-                borderRadius: "50%",
-                background: "var(--gold)",
-                fontSize: "12px",
-                fontWeight: 600,
-                color: "#0a0a0c",
-              }}
-            >
-              {user.email?.[0]?.toUpperCase() || "U"}
-            </div>
+            <Link href="/profile" style={{ textDecoration: "none" }}>
+              <div
+                className="flex items-center justify-center"
+                style={{
+                  width: "32px",
+                  height: "32px",
+                  borderRadius: "50%",
+                  background: "var(--gold)",
+                  fontSize: "12px",
+                  fontWeight: 600,
+                  color: "#0a0a0c",
+                }}
+              >
+                {user.email?.[0]?.toUpperCase() || "U"}
+              </div>
+            </Link>
           </div>
         )}
       </div>


### PR DESCRIPTION
- Move profile link before sign out for better visual order

- Wrap avatar in Link so it also navigates to /profile

- Add profile link to mobile menu for logged-in users`