### PR TITLE
refactor: group session, extract shared helpers and hooks, fix stale auth and swipe race conditions

### DIFF
--- a/app/api/group/[code]/kick/route.ts
+++ b/app/api/group/[code]/kick/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin, getAuthUser } from "@/lib/supabase-server";
-import { isSessionExpired } from "@/lib/group";
+import { resolveSession } from "@/lib/group-api";
 
 // POST /api/group/[code]/kick
 // Host removes a participant from the session.
@@ -35,35 +35,11 @@ export async function POST(
 
   try {
     const supabase = getSupabaseAdmin();
-    const upperCode = code.toUpperCase();
 
-    if (!code || code.length !== 6) {
-      return NextResponse.json(
-        { error: "Invalid session code" },
-        { status: 400 },
-      );
-    }
-
-    // Find the session
-    const { data: session, error: sessionError } = await supabase
-      .from("sessions")
-      .select("id, host_id, status, created_at")
-      .eq("code", upperCode)
-      .single();
-
-    if (sessionError || !session) {
-      return NextResponse.json(
-        { error: "Session not found" },
-        { status: 404 },
-      );
-    }
-
-    if (isSessionExpired(session.created_at)) {
-      return NextResponse.json(
-        { error: "Session expired" },
-        { status: 410 },
-      );
-    }
+    const { session, error: sessionErr } = await resolveSession<{
+      id: string; host_id: string; status: string; created_at: string;
+    }>(supabase, code, "id, host_id, status, created_at");
+    if (sessionErr) return sessionErr;
 
     // Only the host can kick
     if (session.host_id !== user.id) {

--- a/app/api/group/[code]/leave/route.ts
+++ b/app/api/group/[code]/leave/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin, getAuthUser } from "@/lib/supabase-server";
-import { isSessionExpired } from "@/lib/group";
+import { resolveSession, resolveParticipant } from "@/lib/group-api";
 
 // DELETE /api/group/[code]/leave
 // Removes a participant from the session.
@@ -22,47 +22,14 @@ export async function DELETE(
     // No body is fine for authenticated users
   }
 
-  // Must have some way to identify the participant
-  if (!user && !participantId) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401 },
-    );
-  }
-
   try {
     const supabase = getSupabaseAdmin();
-    const upperCode = code.toUpperCase();
 
-    if (!code || code.length !== 6) {
-      return NextResponse.json(
-        { error: "Invalid session code" },
-        { status: 400 },
-      );
-    }
+    const { session, error: sessionErr } = await resolveSession<{
+      id: string; host_id: string; status: string; created_at: string;
+    }>(supabase, code, "id, host_id, status, created_at");
+    if (sessionErr) return sessionErr;
 
-    // Fetch the session
-    const { data: session, error: sessionError } = await supabase
-      .from("sessions")
-      .select("id, host_id, status, created_at")
-      .eq("code", upperCode)
-      .single();
-
-    if (sessionError || !session) {
-      return NextResponse.json(
-        { error: "Session not found" },
-        { status: 404 },
-      );
-    }
-
-    if (isSessionExpired(session.created_at)) {
-      return NextResponse.json(
-        { error: "Session expired" },
-        { status: 410 },
-      );
-    }
-
-    // Can only leave during lobby phase
     if (session.status !== "lobby") {
       return NextResponse.json(
         { error: "Cannot leave a session that has already started" },
@@ -70,27 +37,10 @@ export async function DELETE(
       );
     }
 
-    // Find the participant row
-    let participantQuery = supabase
-      .from("session_participants")
-      .select("id, user_id")
-      .eq("session_id", session.id);
-
-    if (user) {
-      participantQuery = participantQuery.eq("user_id", user.id);
-    } else {
-      participantQuery = participantQuery.eq("id", participantId!);
-    }
-
-    const { data: participant, error: participantError } =
-      await participantQuery.single();
-
-    if (participantError || !participant) {
-      return NextResponse.json(
-        { error: "You are not in this session" },
-        { status: 404 },
-      );
-    }
+    const { participant, error: partErr } = await resolveParticipant<{
+      id: string; user_id: string | null;
+    }>(supabase, session.id, user, participantId, "id, user_id");
+    if (partErr) return partErr;
 
     // Check if this participant is the host
     const isHost = participant.user_id === session.host_id;

--- a/app/api/group/[code]/mood/route.ts
+++ b/app/api/group/[code]/mood/route.ts
@@ -1,10 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin, getAuthUser } from "@/lib/supabase-server";
-import { isSessionExpired } from "@/lib/group";
-import { moodMap, buildTMDBParams } from "@/lib/moodMap";
-import type { DeckFilm } from "@/lib/types";
-
-const DECK_SIZE = 15;
+import { moodMap } from "@/lib/moodMap";
+import { resolveSession, resolveParticipant } from "@/lib/group-api";
+import { buildSharedDeck } from "@/lib/deck";
 
 // POST /api/group/[code]/mood
 // Save a participant's private mood selections.
@@ -15,15 +13,6 @@ export async function POST(
   { params }: { params: Promise<{ code: string }> },
 ) {
   const { code } = await params;
-
-  if (!code || code.length !== 6) {
-    return NextResponse.json(
-      { error: "Invalid session code" },
-      { status: 400 },
-    );
-  }
-
-  const upperCode = code.toUpperCase();
 
   const user = await getAuthUser(request);
   let body: { moods?: string[]; participantId?: string };
@@ -55,26 +44,10 @@ export async function POST(
   try {
     const supabase = getSupabaseAdmin();
 
-    // Fetch session
-    const { data: session, error: sessionError } = await supabase
-      .from("sessions")
-      .select("id, status, created_at")
-      .eq("code", upperCode)
-      .single();
-
-    if (sessionError || !session) {
-      return NextResponse.json(
-        { error: "Session not found" },
-        { status: 404 },
-      );
-    }
-
-    if (isSessionExpired(session.created_at)) {
-      return NextResponse.json(
-        { error: "Session expired" },
-        { status: 410 },
-      );
-    }
+    const { session, error: sessionErr } = await resolveSession<{
+      id: string; status: string; created_at: string;
+    }>(supabase, code);
+    if (sessionErr) return sessionErr;
 
     if (session.status !== "mood") {
       return NextResponse.json(
@@ -83,31 +56,10 @@ export async function POST(
       );
     }
 
-    // Find the participant — auth user by user_id, guest by participantId
-    const participantQuery = supabase
-      .from("session_participants")
-      .select("id, mood_selections")
-      .eq("session_id", session.id);
-
-    if (user) {
-      participantQuery.eq("user_id", user.id);
-    } else if (participantId) {
-      participantQuery.eq("id", participantId);
-    } else {
-      return NextResponse.json(
-        { error: "Unauthorized" },
-        { status: 401 },
-      );
-    }
-
-    const { data: participant } = await participantQuery.single();
-
-    if (!participant) {
-      return NextResponse.json(
-        { error: "You are not in this session" },
-        { status: 403 },
-      );
-    }
+    const { participant, error: partErr } = await resolveParticipant<{
+      id: string; mood_selections: string[] | null;
+    }>(supabase, session.id, user, participantId ?? null, "id, mood_selections");
+    if (partErr) return partErr;
 
     if (participant.mood_selections && participant.mood_selections.length > 0) {
       return NextResponse.json(
@@ -176,151 +128,3 @@ export async function POST(
   }
 }
 
-// TMDB discover result shape — includes genre_ids which we now capture
-interface TMDBDiscoverResult {
-  id: number;
-  title: string;
-  poster_path: string | null;
-  release_date: string;
-  vote_average: number;
-  overview: string;
-  genre_ids: number[];
-}
-
-// Aggregate all participants' moods with weighted frequency,
-// fetch films from TMDB, and build a balanced deck.
-// Each film is tagged with genre_ids and the mood(s) it was sourced from.
-async function buildSharedDeck(
-  participants: { mood_selections: string[] | null }[],
-): Promise<DeckFilm[]> {
-  const apiKey = process.env.TMDB_API_KEY;
-  if (!apiKey) throw new Error("TMDB API key not configured");
-
-  // Count mood frequency across all participants
-  const moodCounts: Record<string, number> = {};
-  for (const p of participants) {
-    if (!p.mood_selections) continue;
-    for (const mood of p.mood_selections) {
-      moodCounts[mood] = (moodCounts[mood] || 0) + 1;
-    }
-  }
-
-  const totalWeight = Object.values(moodCounts).reduce((a, b) => a + b, 0);
-  if (totalWeight === 0) return [];
-
-  // Allocate film slots proportionally
-  const allocations: { mood: string; count: number }[] = [];
-  let allocated = 0;
-
-  const sortedMoods = Object.entries(moodCounts).sort((a, b) => b[1] - a[1]);
-
-  for (const [mood, weight] of sortedMoods) {
-    const share = Math.max(1, Math.round((weight / totalWeight) * DECK_SIZE));
-    allocations.push({ mood, count: share });
-    allocated += share;
-  }
-
-  // Adjust to hit exactly DECK_SIZE — trim from smallest or add to largest
-  while (allocated > DECK_SIZE) {
-    const smallest = allocations[allocations.length - 1];
-    if (smallest.count > 1) {
-      smallest.count--;
-      allocated--;
-    } else {
-      break;
-    }
-  }
-  while (allocated < DECK_SIZE) {
-    allocations[0].count++;
-    allocated++;
-  }
-
-  // Fetch TMDB results for each unique mood in parallel
-  const fetchResults = allocations.map(async ({ mood, count }) => {
-    const moodParams = buildTMDBParams(mood);
-    const url = new URL("https://api.themoviedb.org/3/discover/movie");
-    url.searchParams.set("api_key", apiKey);
-    url.searchParams.set("language", "en-US");
-    url.searchParams.set("page", "1");
-
-    for (const [k, v] of Object.entries(moodParams)) {
-      url.searchParams.set(k, v);
-    }
-
-    const res = await fetch(url.toString());
-    const data = await res.json();
-    const results: (DeckFilm & { _raw_genre_ids: number[] })[] =
-      (data.results ?? []).map((r: TMDBDiscoverResult) => ({
-        id: r.id,
-        title: r.title,
-        poster_path: r.poster_path,
-        release_date: r.release_date,
-        vote_average: r.vote_average,
-        overview: r.overview,
-        genre_ids: r.genre_ids ?? [],
-        mood_keys: [mood],
-        _raw_genre_ids: r.genre_ids ?? [],
-      }));
-
-    return { mood, count, results };
-  });
-
-  const moodResults = await Promise.all(fetchResults);
-
-  // Build deck: pick films per mood allocation, dedup across moods.
-  // If a film appears under multiple moods, merge the mood_keys.
-  const seen = new Map<number, DeckFilm>();
-  const deck: DeckFilm[] = [];
-
-  for (const { mood, count, results } of moodResults) {
-    let picked = 0;
-    for (const film of results) {
-      if (picked >= count) break;
-      const existing = seen.get(film.id);
-      if (existing) {
-        // Film already in deck from another mood — add this mood tag
-        if (!existing.mood_keys.includes(mood)) {
-          existing.mood_keys.push(mood);
-        }
-        continue;
-      }
-      const deckFilm: DeckFilm = {
-        id: film.id,
-        title: film.title,
-        poster_path: film.poster_path,
-        release_date: film.release_date,
-        vote_average: film.vote_average,
-        overview: film.overview,
-        genre_ids: film.genre_ids,
-        mood_keys: [mood],
-      };
-      seen.set(film.id, deckFilm);
-      deck.push(deckFilm);
-      picked++;
-    }
-  }
-
-  // If any mood couldn't fill its allocation, backfill from others
-  if (deck.length < DECK_SIZE) {
-    for (const { mood, results } of moodResults) {
-      for (const film of results) {
-        if (deck.length >= DECK_SIZE) break;
-        if (seen.has(film.id)) continue;
-        const deckFilm: DeckFilm = {
-          id: film.id,
-          title: film.title,
-          poster_path: film.poster_path,
-          release_date: film.release_date,
-          vote_average: film.vote_average,
-          overview: film.overview,
-          genre_ids: film.genre_ids,
-          mood_keys: [mood],
-        };
-        seen.set(film.id, deckFilm);
-        deck.push(deckFilm);
-      }
-    }
-  }
-
-  return deck;
-}

--- a/app/api/group/[code]/ready/route.ts
+++ b/app/api/group/[code]/ready/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin, getAuthUser } from "@/lib/supabase-server";
-import { isSessionExpired } from "@/lib/group";
+import { resolveSession, resolveParticipant } from "@/lib/group-api";
 
 // POST /api/group/[code]/ready
 // Toggles the is_ready flag for the calling participant.
@@ -20,44 +20,13 @@ export async function POST(
     // No body is fine for authenticated users
   }
 
-  if (!user && !participantId) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401 },
-    );
-  }
-
   try {
     const supabase = getSupabaseAdmin();
-    const upperCode = code.toUpperCase();
 
-    if (!code || code.length !== 6) {
-      return NextResponse.json(
-        { error: "Invalid session code" },
-        { status: 400 },
-      );
-    }
-
-    // Find the session
-    const { data: session, error: sessionError } = await supabase
-      .from("sessions")
-      .select("id, status, created_at")
-      .eq("code", upperCode)
-      .single();
-
-    if (sessionError || !session) {
-      return NextResponse.json(
-        { error: "Session not found" },
-        { status: 404 },
-      );
-    }
-
-    if (isSessionExpired(session.created_at)) {
-      return NextResponse.json(
-        { error: "Session expired" },
-        { status: 410 },
-      );
-    }
+    const { session, error: sessionErr } = await resolveSession<{
+      id: string; status: string; created_at: string;
+    }>(supabase, code);
+    if (sessionErr) return sessionErr;
 
     if (session.status !== "lobby") {
       return NextResponse.json(
@@ -66,27 +35,10 @@ export async function POST(
       );
     }
 
-    // Find the participant
-    let query = supabase
-      .from("session_participants")
-      .select("id, is_ready")
-      .eq("session_id", session.id);
-
-    if (user) {
-      query = query.eq("user_id", user.id);
-    } else {
-      query = query.eq("id", participantId!);
-    }
-
-    const { data: participant, error: participantError } =
-      await query.single();
-
-    if (participantError || !participant) {
-      return NextResponse.json(
-        { error: "You are not in this session" },
-        { status: 404 },
-      );
-    }
+    const { participant, error: partErr } = await resolveParticipant<{
+      id: string; is_ready: boolean;
+    }>(supabase, session.id, user, participantId, "id, is_ready");
+    if (partErr) return partErr;
 
     // Toggle the ready state
     const newReady = !participant.is_ready;

--- a/app/api/group/[code]/results/route.ts
+++ b/app/api/group/[code]/results/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin, getAuthUser } from "@/lib/supabase-server";
-import { isSessionExpired } from "@/lib/group";
+import { classifyTier } from "@/lib/group";
+import { resolveSession } from "@/lib/group-api";
 import type {
   DeckFilm,
   SwipeVote,
   MatchResult,
-  ResultTier,
   GroupResultsPayload,
 } from "@/lib/types";
 
@@ -26,14 +26,6 @@ export async function GET(
 ) {
   const { code } = await params;
 
-  if (!code || code.length !== 6) {
-    return NextResponse.json(
-      { error: "Invalid session code" },
-      { status: 400 },
-    );
-  }
-
-  const upperCode = code.toUpperCase();
   const user = await getAuthUser(request);
   const participantIdParam = request.nextUrl.searchParams.get("participantId");
 
@@ -44,25 +36,11 @@ export async function GET(
   try {
     const supabase = getSupabaseAdmin();
 
-    // Fetch session + deck
-    const { data: session, error: sessionError } = await supabase
-      .from("sessions")
-      .select("id, code, status, movie_deck, created_at")
-      .eq("code", upperCode)
-      .single();
+    const { session, error: sessionErr } = await resolveSession<{
+      id: string; code: string; status: string; movie_deck: DeckFilm[] | null; created_at: string;
+    }>(supabase, code, "id, code, status, movie_deck, created_at");
+    if (sessionErr) return sessionErr;
 
-    if (sessionError || !session) {
-      return NextResponse.json(
-        { error: "Session not found" },
-        { status: 404 },
-      );
-    }
-
-    if (isSessionExpired(session.created_at)) {
-      return NextResponse.json({ error: "Session expired" }, { status: 410 });
-    }
-
-    // Results are only available after everyone has finished swiping
     if (session.status !== "done") {
       return NextResponse.json(
         { error: "Results are not ready yet" },
@@ -198,19 +176,3 @@ export async function GET(
   }
 }
 
-// Tier rules:
-// - perfect: every participant said yes
-// - strong:  nobody said no AND at least half said yes (maybes OK)
-// - miss:    everything else (any no vote, or too few yes votes)
-function classifyTier(
-  yesCount: number,
-  noCount: number,
-  participantCount: number,
-): ResultTier {
-  if (participantCount === 0) return "miss";
-  if (yesCount === participantCount) return "perfect";
-  if (noCount === 0 && yesCount >= Math.ceil(participantCount / 2)) {
-    return "strong";
-  }
-  return "miss";
-}

--- a/app/api/group/[code]/route.ts
+++ b/app/api/group/[code]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase-server";
-import { isSessionExpired } from "@/lib/group";
+import { resolveSession } from "@/lib/group-api";
 
 // GET /api/group/[code]
 // Returns session details + participant list for the lobby.
@@ -11,37 +11,13 @@ export async function GET(
 ) {
   const { code } = await params;
 
-  if (!code || code.length !== 6) {
-    return NextResponse.json(
-      { error: "Invalid session code" },
-      { status: 400 },
-    );
-  }
-
   try {
     const supabase = getSupabaseAdmin();
-    const upperCode = code.toUpperCase();
 
-    // Fetch the session
-    const { data: session, error: sessionError } = await supabase
-      .from("sessions")
-      .select("id, code, host_id, status, created_at")
-      .eq("code", upperCode)
-      .single();
-
-    if (sessionError || !session) {
-      return NextResponse.json(
-        { error: "Session not found" },
-        { status: 404 },
-      );
-    }
-
-    if (isSessionExpired(session.created_at)) {
-      return NextResponse.json(
-        { error: "Session expired" },
-        { status: 410 },
-      );
-    }
+    const { session, error: sessionErr } = await resolveSession<{
+      id: string; code: string; host_id: string; status: string; created_at: string;
+    }>(supabase, code, "id, code, host_id, status, created_at");
+    if (sessionErr) return sessionErr;
 
     // Fetch participants ordered by join time (host will be first)
     const { data: participants, error: participantsError } = await supabase

--- a/app/api/group/[code]/start/route.ts
+++ b/app/api/group/[code]/start/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin, getAuthUser } from "@/lib/supabase-server";
-import { isSessionExpired } from "@/lib/group";
+import { resolveSession } from "@/lib/group-api";
 
 // POST /api/group/[code]/start
 // Host transitions the session from "lobby" to "mood".
@@ -22,35 +22,10 @@ export async function POST(
   try {
     const supabase = getSupabaseAdmin();
 
-    if (!code || code.length !== 6) {
-      return NextResponse.json(
-        { error: "Invalid session code" },
-        { status: 400 },
-      );
-    }
-
-    const upperCode = code.toUpperCase();
-
-    // Fetch the session
-    const { data: session, error: sessionError } = await supabase
-      .from("sessions")
-      .select("id, host_id, status, created_at")
-      .eq("code", upperCode)
-      .single();
-
-    if (sessionError || !session) {
-      return NextResponse.json(
-        { error: "Session not found" },
-        { status: 404 },
-      );
-    }
-
-    if (isSessionExpired(session.created_at)) {
-      return NextResponse.json(
-        { error: "Session expired" },
-        { status: 410 },
-      );
-    }
+    const { session, error: sessionErr } = await resolveSession<{
+      id: string; host_id: string; status: string; created_at: string;
+    }>(supabase, code, "id, host_id, status, created_at");
+    if (sessionErr) return sessionErr;
 
     // Only the host can start
     if (session.host_id !== user.id) {

--- a/app/api/group/[code]/swipe/route.ts
+++ b/app/api/group/[code]/swipe/route.ts
@@ -1,59 +1,29 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin, getAuthUser } from "@/lib/supabase-server";
-import { isSessionExpired } from "@/lib/group";
+import { resolveSession, resolveParticipant } from "@/lib/group-api";
 import type { DeckFilm, SwipeVote } from "@/lib/types";
 
 const VALID_VOTES: SwipeVote[] = ["yes", "no", "maybe"];
 
 // GET /api/group/[code]/swipe
 // Returns the current participant's swipe progress for this session.
-// Used to resume swiping after a page refresh
-// movies that have already been voted on.
+// Used to resume swiping after a page refresh.
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ code: string }> },
 ) {
   const { code } = await params;
 
-  if (!code || code.length !== 6) {
-    return NextResponse.json(
-      { error: "Invalid session code" },
-      { status: 400 },
-    );
-  }
-
-  const upperCode = code.toUpperCase();
-
   const user = await getAuthUser(request);
   const participantId = request.nextUrl.searchParams.get("participantId");
-
-  if (!user && !participantId) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
 
   try {
     const supabase = getSupabaseAdmin();
 
-    // Fetch session with movie deck
-    const { data: session, error: sessionError } = await supabase
-      .from("sessions")
-      .select("id, status, movie_deck, created_at")
-      .eq("code", upperCode)
-      .single();
-
-    if (sessionError || !session) {
-      return NextResponse.json(
-        { error: "Session not found" },
-        { status: 404 },
-      );
-    }
-
-    if (isSessionExpired(session.created_at)) {
-      return NextResponse.json(
-        { error: "Session expired" },
-        { status: 410 },
-      );
-    }
+    const { session, error: sessionErr } = await resolveSession<{
+      id: string; status: string; movie_deck: DeckFilm[] | null; created_at: string;
+    }>(supabase, code, "id, status, movie_deck, created_at");
+    if (sessionErr) return sessionErr;
 
     if (session.status !== "swiping" && session.status !== "done") {
       return NextResponse.json(
@@ -62,26 +32,10 @@ export async function GET(
       );
     }
 
-    // Find the participant
-    const participantQuery = supabase
-      .from("session_participants")
-      .select("id, has_swiped")
-      .eq("session_id", session.id);
-
-    if (user) {
-      participantQuery.eq("user_id", user.id);
-    } else {
-      participantQuery.eq("id", participantId!);
-    }
-
-    const { data: participant } = await participantQuery.single();
-
-    if (!participant) {
-      return NextResponse.json(
-        { error: "You are not in this session" },
-        { status: 403 },
-      );
-    }
+    const { participant, error: partErr } = await resolveParticipant<{
+      id: string; has_swiped: boolean;
+    }>(supabase, session.id, user, participantId, "id, has_swiped");
+    if (partErr) return partErr;
 
     // Fetch this participant's existing swipes
     const { data: swipes } = await supabase
@@ -93,13 +47,14 @@ export async function GET(
     // Fetch all participants' completion status
     const { data: allParticipants } = await supabase
       .from("session_participants")
-      .select("id, nickname, has_swiped")
+      .select("id, user_id, nickname, has_swiped")
       .eq("session_id", session.id);
 
     const deck: DeckFilm[] = session.movie_deck ?? [];
     const votedIds = new Set((swipes ?? []).map((s) => s.movie_id));
 
     return NextResponse.json({
+      sessionId: session.id,
       deck,
       swipes: swipes ?? [],
       progress: {
@@ -108,6 +63,7 @@ export async function GET(
       },
       participants: (allParticipants ?? []).map((p) => ({
         id: p.id,
+        user_id: p.user_id,
         nickname: p.nickname,
         has_swiped: p.has_swiped,
       })),
@@ -129,15 +85,6 @@ export async function POST(
   { params }: { params: Promise<{ code: string }> },
 ) {
   const { code } = await params;
-
-  if (!code || code.length !== 6) {
-    return NextResponse.json(
-      { error: "Invalid session code" },
-      { status: 400 },
-    );
-  }
-
-  const upperCode = code.toUpperCase();
 
   const user = await getAuthUser(request);
   let body: { participantId?: string; movieId?: number; vote?: string };
@@ -165,33 +112,13 @@ export async function POST(
     );
   }
 
-  if (!user && !participantId) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
   try {
     const supabase = getSupabaseAdmin();
 
-    // Fetch session with movie deck
-    const { data: session, error: sessionError } = await supabase
-      .from("sessions")
-      .select("id, status, movie_deck, created_at")
-      .eq("code", upperCode)
-      .single();
-
-    if (sessionError || !session) {
-      return NextResponse.json(
-        { error: "Session not found" },
-        { status: 404 },
-      );
-    }
-
-    if (isSessionExpired(session.created_at)) {
-      return NextResponse.json(
-        { error: "Session expired" },
-        { status: 410 },
-      );
-    }
+    const { session, error: sessionErr } = await resolveSession<{
+      id: string; status: string; movie_deck: DeckFilm[] | null; created_at: string;
+    }>(supabase, code, "id, status, movie_deck, created_at");
+    if (sessionErr) return sessionErr;
 
     if (session.status !== "swiping") {
       return NextResponse.json(
@@ -211,26 +138,10 @@ export async function POST(
       );
     }
 
-    // Find the participant
-    const participantQuery = supabase
-      .from("session_participants")
-      .select("id, has_swiped")
-      .eq("session_id", session.id);
-
-    if (user) {
-      participantQuery.eq("user_id", user.id);
-    } else {
-      participantQuery.eq("id", participantId!);
-    }
-
-    const { data: participant } = await participantQuery.single();
-
-    if (!participant) {
-      return NextResponse.json(
-        { error: "You are not in this session" },
-        { status: 403 },
-      );
-    }
+    const { participant, error: partErr } = await resolveParticipant<{
+      id: string; has_swiped: boolean;
+    }>(supabase, session.id, user, participantId ?? null, "id, has_swiped");
+    if (partErr) return partErr;
 
     if (participant.has_swiped) {
       return NextResponse.json(

--- a/app/group/[code]/mood/page.tsx
+++ b/app/group/[code]/mood/page.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { useEffect, useState, useRef, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useAuth } from "@/components/AuthProvider";
-import { supabase } from "@/lib/supabase";
+import { useParticipantId } from "@/lib/useParticipantId";
+import { useGroupRealtime } from "@/lib/useGroupRealtime";
+import { getAuthHeaders } from "@/lib/getAuthToken";
 import { allMoods } from "@/lib/moodMap";
 import MoodCard from "@/components/dashboard/MoodCard";
 
@@ -24,7 +26,7 @@ export default function GroupMoodPage() {
   const params = useParams<{ code: string }>();
   const code = params.code;
   const router = useRouter();
-  const { user, session: authSession, loading: authLoading } = useAuth();
+  const { user, loading: authLoading } = useAuth();
 
   const [phase, setPhase] = useState<Phase>("selecting");
   const [sessionInfo, setSessionInfo] = useState<SessionInfo | null>(null);
@@ -34,14 +36,8 @@ export default function GroupMoodPage() {
   const [error, setError] = useState<string | null>(null);
 
   const [sessionId, setSessionId] = useState<string | null>(null);
-  const [participantId, setParticipantId] = useState<string | null>(null);
-  const fetchRef = useRef<() => Promise<void>>(undefined);
+  const { participantId } = useParticipantId();
   const redirectingRef = useRef(false);
-
-  useEffect(() => {
-    const stored = localStorage.getItem("participantId");
-    if (stored) setParticipantId(stored);
-  }, []);
 
   const fetchState = useCallback(async () => {
     if (redirectingRef.current) return;
@@ -105,8 +101,6 @@ export default function GroupMoodPage() {
     }
   }, [code, router, user, participantId]);
 
-  fetchRef.current = fetchState;
-
   // Initial fetch
   useEffect(() => {
     if (!authLoading) {
@@ -121,56 +115,13 @@ export default function GroupMoodPage() {
     }
   }, [sessionInfo, sessionId]);
 
-  // Polling fallback every 2s
-  useEffect(() => {
-    if (loading || phase === "building") return;
-    const interval = setInterval(() => {
-      fetchRef.current?.();
-    }, 2000);
-    return () => clearInterval(interval);
-  }, [loading, phase]);
-
-  // Realtime subscriptions
-  useEffect(() => {
-    if (!sessionId) return;
-
-    const participantsChannel = supabase
-      .channel(`mood-participants-${sessionId}`)
-      .on(
-        "postgres_changes",
-        {
-          event: "UPDATE",
-          schema: "public",
-          table: "session_participants",
-          filter: `session_id=eq.${sessionId}`,
-        },
-        () => {
-          fetchRef.current?.();
-        },
-      )
-      .subscribe();
-
-    const sessionChannel = supabase
-      .channel(`mood-session-${sessionId}`)
-      .on(
-        "postgres_changes",
-        {
-          event: "UPDATE",
-          schema: "public",
-          table: "sessions",
-          filter: `id=eq.${sessionId}`,
-        },
-        () => {
-          fetchRef.current?.();
-        },
-      )
-      .subscribe();
-
-    return () => {
-      supabase.removeChannel(participantsChannel);
-      supabase.removeChannel(sessionChannel);
-    };
-  }, [sessionId]);
+  // Realtime + polling
+  useGroupRealtime({
+    sessionId,
+    channelPrefix: "mood",
+    onUpdate: fetchState,
+    paused: loading || phase === "building",
+  });
 
   const toggleMood = (key: string) => {
     if (phase !== "selecting") return;
@@ -191,17 +142,13 @@ export default function GroupMoodPage() {
     setError(null);
 
     try {
-      const headers: Record<string, string> = {
-        "Content-Type": "application/json",
-      };
-      if (authSession?.access_token) {
-        headers.Authorization = `Bearer ${authSession.access_token}`;
-      }
+      const headers = await getAuthHeaders();
+      const isGuest = !headers.Authorization;
 
       const body: { moods: string[]; participantId?: string } = {
         moods: Array.from(selectedMoods),
       };
-      if (!authSession?.access_token && participantId) {
+      if (isGuest && participantId) {
         body.participantId = participantId;
       }
 

--- a/app/group/[code]/page.tsx
+++ b/app/group/[code]/page.tsx
@@ -3,7 +3,8 @@
 import { useEffect, useState, useCallback, useRef } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useAuth } from "@/components/AuthProvider";
-import { supabase } from "@/lib/supabase";
+import { useParticipantId } from "@/lib/useParticipantId";
+import { useGroupRealtime } from "@/lib/useGroupRealtime";
 import ParticipantList from "@/components/group/ParticipantList";
 import LobbyActions from "@/components/group/LobbyActions";
 import InviteStrip from "@/components/group/InviteStrip";
@@ -32,7 +33,7 @@ export default function LobbyPage() {
   const params = useParams<{ code: string }>();
   const code = params.code;
   const router = useRouter();
-  const { user, session: authSession, loading: authLoading } = useAuth();
+  const { user, loading: authLoading } = useAuth();
 
   const [sessionData, setSessionData] = useState<SessionData | null>(null);
   const [participants, setParticipants] = useState<Participant[]>([]);
@@ -41,15 +42,10 @@ export default function LobbyPage() {
   const [elapsed, setElapsed] = useState("");
 
   const [sessionId, setSessionId] = useState<string | null>(null);
-  const [participantId, setParticipantId] = useState<string | null>(null);
+  const { participantId } = useParticipantId();
   const prevParticipantsRef = useRef<Participant[]>([]);
   const redirectingRef = useRef(false);
   const { toasts, addToast } = useToasts();
-
-  useEffect(() => {
-    const stored = localStorage.getItem("participantId");
-    if (stored) setParticipantId(stored);
-  }, []);
 
   const isHost = user ? user.id === sessionData?.host_id : false;
 
@@ -135,9 +131,6 @@ export default function LobbyPage() {
     }
   }, [code, router, diffParticipants]);
 
-  const fetchLobbyRef = useRef(fetchLobby);
-  fetchLobbyRef.current = fetchLobby;
-
   // Initial fetch
   useEffect(() => {
     if (!authLoading) {
@@ -152,60 +145,14 @@ export default function LobbyPage() {
     }
   }, [sessionData, sessionId]);
 
-  // Realtime subscriptions
-  useEffect(() => {
-    if (!sessionId) return;
-
-    const participantsChannel = supabase
-      .channel(`lobby-participants-${sessionId}`)
-      .on(
-        "postgres_changes",
-        {
-          event: "*",
-          schema: "public",
-          table: "session_participants",
-          filter: `session_id=eq.${sessionId}`,
-        },
-        () => {
-          fetchLobbyRef.current();
-        },
-      )
-      .subscribe();
-
-    const sessionChannel = supabase
-      .channel(`lobby-session-${sessionId}`)
-      .on(
-        "postgres_changes",
-        {
-          event: "*",
-          schema: "public",
-          table: "sessions",
-          filter: `id=eq.${sessionId}`,
-        },
-        (payload) => {
-          if (payload.eventType === "DELETE") {
-            router.replace("/group");
-            return;
-          }
-          fetchLobbyRef.current();
-        },
-      )
-      .subscribe();
-
-    return () => {
-      supabase.removeChannel(participantsChannel);
-      supabase.removeChannel(sessionChannel);
-    };
-  }, [sessionId, code, router]);
-
-  // Polling fallback every 2s
-  useEffect(() => {
-    if (loading) return;
-    const interval = setInterval(() => {
-      fetchLobbyRef.current();
-    }, 2000);
-    return () => clearInterval(interval);
-  }, [loading]);
+  // Realtime + polling
+  useGroupRealtime({
+    sessionId,
+    channelPrefix: "lobby",
+    onUpdate: fetchLobby,
+    onDelete: () => router.replace("/group"),
+    paused: loading,
+  });
 
   // Session timer
   useEffect(() => {
@@ -429,7 +376,6 @@ export default function LobbyPage() {
               hostId={sessionData.host_id}
               isHost={isHost}
               sessionCode={code}
-              accessToken={authSession?.access_token}
             />
           </div>
 
@@ -449,7 +395,6 @@ export default function LobbyPage() {
               allReady={allReady}
               selfReady={selfReady}
               sessionCode={code}
-              accessToken={authSession?.access_token}
               participantId={participantId}
               onSessionStarted={() => {
                 redirectingRef.current = true;

--- a/app/group/[code]/results/page.tsx
+++ b/app/group/[code]/results/page.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState, useCallback } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import { useAuth } from "@/components/AuthProvider";
+import { useParticipantId } from "@/lib/useParticipantId";
+import { getAuthHeaders } from "@/lib/getAuthToken";
 import TopPickCard from "@/components/group/TopPickCard";
 import TierSection from "@/components/group/TierSection";
 import type { GroupResultsPayload, Provider } from "@/lib/types";
@@ -12,47 +14,29 @@ export default function GroupResultsPage() {
   const params = useParams<{ code: string }>();
   const code = params.code;
   const router = useRouter();
-  const { session: authSession, loading: authLoading } = useAuth();
+  const { loading: authLoading } = useAuth();
 
   const [data, setData] = useState<GroupResultsPayload | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [participantId, setParticipantId] = useState<string | null>(null);
-  // Tracks whether we've finished reading participantId from localStorage.
-  // Without this flag, a guest's first fetch fires before the localStorage
-  // read completes and the API rejects it with 401.
-  const [participantIdReady, setParticipantIdReady] = useState(false);
+  const { participantId, ready: participantIdReady } = useParticipantId();
 
   const [providers, setProviders] = useState<Provider[] | null>(null);
   const [providersLoading, setProvidersLoading] = useState(false);
 
-  useEffect(() => {
-    const stored = localStorage.getItem("participantId");
-    if (stored) setParticipantId(stored);
-    setParticipantIdReady(true);
-  }, []);
-
-  const getHeaders = useCallback(() => {
-    const headers: Record<string, string> = { "Content-Type": "application/json" };
-    if (authSession?.access_token) {
-      headers.Authorization = `Bearer ${authSession.access_token}`;
-    }
-    return headers;
-  }, [authSession]);
-
   // Load the results payload
   const fetchResults = useCallback(async () => {
-    // Clear any previous error — if a retry succeeds, stale error state
-    // would otherwise keep the error screen visible forever
     setError(null);
     try {
+      const headers = await getAuthHeaders();
+      const isGuest = !headers.Authorization;
       const pidParam =
-        !authSession?.access_token && participantId
+        isGuest && participantId
           ? `?participantId=${participantId}`
           : "";
 
       const res = await fetch(`/api/group/${code}/results${pidParam}`, {
-        headers: getHeaders(),
+        headers,
       });
 
       if (!res.ok) {
@@ -78,7 +62,7 @@ export default function GroupResultsPage() {
     } finally {
       setLoading(false);
     }
-  }, [code, router, authSession, participantId, getHeaders]);
+  }, [code, router, participantId]);
 
   useEffect(() => {
     // Wait until both auth has resolved AND we've tried to read participantId

--- a/app/group/[code]/swipe/page.tsx
+++ b/app/group/[code]/swipe/page.tsx
@@ -1,22 +1,18 @@
 "use client";
 
-import { useEffect, useState, useRef, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useAuth } from "@/components/AuthProvider";
-import { supabase } from "@/lib/supabase";
+import { useParticipantId } from "@/lib/useParticipantId";
+import { useGroupRealtime } from "@/lib/useGroupRealtime";
+import { getAuthHeaders } from "@/lib/getAuthToken";
 import SwipeDeck from "@/components/group/SwipeDeck";
 import type { DeckFilm, SwipeVote } from "@/lib/types";
-
-const AVATAR_COLORS = [
-  { bg: "var(--gold)", text: "#0a0a0c" },
-  { bg: "var(--teal)", text: "#0a0a0c" },
-  { bg: "var(--rose)", text: "#fff" },
-  { bg: "var(--blue)", text: "#fff" },
-  { bg: "var(--violet)", text: "#fff" },
-];
+import { AVATAR_COLORS } from "@/lib/constants";
 
 interface ParticipantStatus {
   id: string;
+  user_id: string | null;
   nickname: string;
   has_swiped: boolean;
 }
@@ -25,7 +21,7 @@ export default function GroupSwipePage() {
   const params = useParams<{ code: string }>();
   const code = params.code;
   const router = useRouter();
-  const { user, session: authSession, loading: authLoading } = useAuth();
+  const { user, loading: authLoading } = useAuth();
 
   const [deck, setDeck] = useState<DeckFilm[]>([]);
   const [startIndex, setStartIndex] = useState(0);
@@ -38,36 +34,23 @@ export default function GroupSwipePage() {
   const [error, setError] = useState<string | null>(null);
 
   const [sessionId, setSessionId] = useState<string | null>(null);
-  const [participantId, setParticipantId] = useState<string | null>(null);
-  const fetchRef = useRef<() => Promise<void>>(undefined);
+  const { participantId, ready: participantIdReady } = useParticipantId();
   const redirectingRef = useRef(false);
-
-  useEffect(() => {
-    const stored = localStorage.getItem("participantId");
-    if (stored) setParticipantId(stored);
-  }, []);
-
-  const getHeaders = useCallback(() => {
-    const headers: Record<string, string> = {
-      "Content-Type": "application/json",
-    };
-    if (authSession?.access_token) {
-      headers.Authorization = `Bearer ${authSession.access_token}`;
-    }
-    return headers;
-  }, [authSession]);
 
   const fetchSwipeState = useCallback(async () => {
     if (redirectingRef.current) return;
+    setError(null);
 
     try {
+      const headers = await getAuthHeaders();
+      const isGuest = !headers.Authorization;
       const pidParam =
-        !authSession?.access_token && participantId
+        isGuest && participantId
           ? `?participantId=${participantId}`
           : "";
 
       const res = await fetch(`/api/group/${code}/swipe${pidParam}`, {
-        headers: getHeaders(),
+        headers,
       });
 
       if (!res.ok) {
@@ -97,28 +80,26 @@ export default function GroupSwipePage() {
 
       const data = await res.json();
 
-      if (data.deck?.length > 0 && !sessionId) {
-        const lobbyRes = await fetch(`/api/group/${code}`);
-        const lobbyData = await lobbyRes.json();
-        if (lobbyData.session?.id) {
-          setSessionId(lobbyData.session.id);
-        }
+      if (data.sessionId && !sessionId) {
+        setSessionId(data.sessionId);
       }
 
       setDeck(data.deck);
       setParticipants(data.participants);
       setSessionStatus(data.sessionStatus);
 
-      const voteMap: Record<string, SwipeVote> = {};
-      for (const s of data.swipes) {
-        voteMap[String(s.movie_id)] = s.vote;
-      }
-      setMyVotes(voteMap);
-      setStartIndex(data.progress.swiped);
+      setMyVotes((prev) => {
+        const merged = { ...prev };
+        for (const s of data.swipes) {
+          merged[String(s.movie_id)] = s.vote;
+        }
+        return merged;
+      });
+      setStartIndex((prev) => Math.max(prev, data.progress.swiped));
 
       const currentPid = participantId;
       const me = data.participants.find((p: ParticipantStatus) => {
-        if (user) return true;
+        if (user) return p.user_id === user.id;
         return p.id === currentPid;
       });
       if (me?.has_swiped || data.progress.swiped >= data.progress.total) {
@@ -139,100 +120,96 @@ export default function GroupSwipePage() {
     } finally {
       setLoading(false);
     }
-  }, [code, router, user, participantId, authSession, sessionId, getHeaders]);
-
-  fetchRef.current = fetchSwipeState;
+  }, [code, router, user, participantId, sessionId]);
 
   useEffect(() => {
-    if (!authLoading) fetchSwipeState();
-  }, [authLoading, fetchSwipeState]);
+    if (!authLoading && participantIdReady) fetchSwipeState();
+  }, [authLoading, participantIdReady, fetchSwipeState]);
 
+  // Detect local completion — all cards in the deck have a vote
   useEffect(() => {
-    if (loading) return;
-    const interval = setInterval(() => {
-      fetchRef.current?.();
-    }, 2000);
-    return () => clearInterval(interval);
-  }, [loading]);
+    if (deck.length > 0 && Object.keys(myVotes).length >= deck.length) {
+      setIsDone(true);
+    }
+  }, [myVotes, deck.length]);
 
-  useEffect(() => {
-    if (!sessionId) return;
+  // Realtime + polling
+  useGroupRealtime({
+    sessionId,
+    channelPrefix: "swipe",
+    onUpdate: fetchSwipeState,
+    paused: loading,
+  });
 
-    const participantsChannel = supabase
-      .channel(`swipe-participants-${sessionId}`)
-      .on(
-        "postgres_changes",
-        {
-          event: "UPDATE",
-          schema: "public",
-          table: "session_participants",
-          filter: `session_id=eq.${sessionId}`,
-        },
-        () => { fetchRef.current?.(); },
-      )
-      .subscribe();
+  const sendVote = useCallback(
+    async (movieId: number, vote: SwipeVote) => {
+      const headers = await getAuthHeaders();
+      const isGuest = !headers.Authorization;
 
-    const sessionChannel = supabase
-      .channel(`swipe-session-${sessionId}`)
-      .on(
-        "postgres_changes",
-        {
-          event: "UPDATE",
-          schema: "public",
-          table: "sessions",
-          filter: `id=eq.${sessionId}`,
-        },
-        () => { fetchRef.current?.(); },
-      )
-      .subscribe();
+      const body: { movieId: number; vote: SwipeVote; participantId?: string } = {
+        movieId,
+        vote,
+      };
+      if (isGuest && participantId) {
+        body.participantId = participantId;
+      }
 
-    return () => {
-      supabase.removeChannel(participantsChannel);
-      supabase.removeChannel(sessionChannel);
-    };
-  }, [sessionId]);
+      const res = await fetch(`/api/group/${code}/swipe`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+      });
+
+      return res;
+    },
+    [code, participantId],
+  );
 
   const handleVote = useCallback(
     async (movieId: number, vote: SwipeVote) => {
+      // Optimistic — the card is already gone from SwipeDeck, so we never
+      // roll this back. If the POST fails we retry once; the polling will
+      // eventually sync the server state regardless.
       setMyVotes((prev) => ({ ...prev, [String(movieId)]: vote }));
 
       try {
-        const body: { movieId: number; vote: SwipeVote; participantId?: string } = {
-          movieId,
-          vote,
-        };
-        if (!authSession?.access_token && participantId) {
-          body.participantId = participantId;
-        }
+        const res = await sendVote(movieId, vote);
 
-        const res = await fetch(`/api/group/${code}/swipe`, {
-          method: "POST",
-          headers: getHeaders(),
-          body: JSON.stringify(body),
-        });
-
-        const data = await res.json();
-
-        if (!res.ok) {
-          setMyVotes((prev) => {
-            const next = { ...prev };
-            delete next[String(movieId)];
-            return next;
-          });
+        if (res.ok) {
+          const data = await res.json();
+          if (data.participantDone) setIsDone(true);
+          if (data.allDone) setAllDone(true);
           return;
         }
 
-        if (data.participantDone) setIsDone(true);
-        if (data.allDone) setAllDone(true);
+        // 409 = already recorded, nothing to retry
+        if (res.status === 409) return;
+
+        // Other server error — retry once after a short delay
+        await new Promise((r) => setTimeout(r, 800));
+        const retry = await sendVote(movieId, vote);
+        if (retry.ok) {
+          const data = await retry.json();
+          if (data.participantDone) setIsDone(true);
+          if (data.allDone) setAllDone(true);
+        }
       } catch {
-        setMyVotes((prev) => {
-          const next = { ...prev };
-          delete next[String(movieId)];
-          return next;
-        });
+        // Network error — retry once
+        try {
+          await new Promise((r) => setTimeout(r, 800));
+          const retry = await sendVote(movieId, vote);
+          if (retry.ok) {
+            const data = await retry.json();
+            if (data.participantDone) setIsDone(true);
+            if (data.allDone) setAllDone(true);
+          }
+        } catch {
+          // Both attempts failed — the optimistic vote stays in myVotes
+          // so the done screen still shows. Polling will sync server state.
+        }
       }
     },
-    [code, authSession, participantId, getHeaders],
+    [sendVote],
   );
 
   const voteCounts = Object.values(myVotes).reduce(
@@ -591,7 +568,7 @@ export default function GroupSwipePage() {
             ) : (
               <button
                 className="font-sans cursor-pointer"
-                onClick={() => router.push(`/group/${code}/results`)}
+                onClick={() => router.replace(`/group/${code}/results`)}
                 style={{
                   display: "inline-flex",
                   alignItems: "center",

--- a/components/group/LobbyActions.tsx
+++ b/components/group/LobbyActions.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { getAuthHeaders } from "@/lib/getAuthToken";
 
 interface LobbyActionsProps {
   isHost: boolean;
@@ -8,7 +9,6 @@ interface LobbyActionsProps {
   allReady: boolean;
   selfReady: boolean;
   sessionCode: string;
-  accessToken: string | undefined;
   participantId: string | null;
   onSessionStarted: () => void;
   onReadyToggled: () => void;
@@ -22,7 +22,6 @@ export default function LobbyActions({
   allReady,
   selfReady,
   sessionCode,
-  accessToken,
   participantId,
   onSessionStarted,
   onReadyToggled,
@@ -44,7 +43,7 @@ export default function LobbyActions({
     try {
       const res = await fetch(`/api/group/${sessionCode}/start`, {
         method: "POST",
-        headers: { Authorization: `Bearer ${accessToken}` },
+        headers: await getAuthHeaders(),
       });
 
       const data = await res.json();
@@ -66,25 +65,27 @@ export default function LobbyActions({
     setTogglingReady(true);
 
     try {
-      const headers: Record<string, string> = {
-        "Content-Type": "application/json",
-      };
-      if (accessToken) {
-        headers.Authorization = `Bearer ${accessToken}`;
-      }
+      const headers = await getAuthHeaders();
+      const isGuest = !headers.Authorization;
 
-      const body = !accessToken && participantId
+      const body = isGuest && participantId
         ? { participantId }
         : {};
 
-      await fetch(`/api/group/${sessionCode}/ready`, {
+      const res = await fetch(`/api/group/${sessionCode}/ready`, {
         method: "POST",
         headers,
         body: JSON.stringify(body),
       });
 
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        setError(data?.error || "Failed to toggle ready state");
+      }
+
       onReadyToggled();
     } catch {
+      setError("Network error — please try again");
       onReadyToggled();
     } finally {
       setTogglingReady(false);
@@ -96,14 +97,10 @@ export default function LobbyActions({
     setLeaving(true);
 
     try {
-      const headers: Record<string, string> = {
-        "Content-Type": "application/json",
-      };
-      if (accessToken) {
-        headers.Authorization = `Bearer ${accessToken}`;
-      }
+      const headers = await getAuthHeaders();
+      const isGuest = !headers.Authorization;
 
-      const body = !accessToken && participantId
+      const body = isGuest && participantId
         ? JSON.stringify({ participantId })
         : undefined;
 

--- a/components/group/ParticipantList.tsx
+++ b/components/group/ParticipantList.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState } from "react";
+import { AVATAR_COLORS } from "@/lib/constants";
+import { getAuthHeaders } from "@/lib/getAuthToken";
 
 interface Participant {
   id: string;
@@ -15,17 +17,7 @@ interface ParticipantListProps {
   hostId: string;
   isHost: boolean;
   sessionCode: string;
-  accessToken: string | undefined;
 }
-
-const AVATAR_COLORS = [
-  "var(--teal)",
-  "var(--gold)",
-  "var(--blue)",
-  "var(--violet)",
-  "var(--rose)",
-  "var(--ember)",
-];
 
 function getInitials(name: string): string {
   const parts = name.trim().split(/\s+/);
@@ -40,7 +32,6 @@ export default function ParticipantList({
   hostId,
   isHost,
   sessionCode,
-  accessToken,
 }: ParticipantListProps) {
   const [kickingId, setKickingId] = useState<string | null>(null);
   const [confirmKickId, setConfirmKickId] = useState<string | null>(null);
@@ -54,10 +45,7 @@ export default function ParticipantList({
     try {
       const res = await fetch(`/api/group/${sessionCode}/kick`, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${accessToken}`,
-        },
+        headers: await getAuthHeaders(),
         body: JSON.stringify({ participantId }),
       });
 
@@ -93,7 +81,7 @@ export default function ParticipantList({
     >
       {participants.map((p, i) => {
         const isThisHost = p.user_id === hostId;
-        const color = AVATAR_COLORS[i % AVATAR_COLORS.length];
+        const color = AVATAR_COLORS[i % AVATAR_COLORS.length].bg;
 
         return (
           <div

--- a/components/group/SessionCreator.tsx
+++ b/components/group/SessionCreator.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/components/AuthProvider";
+import { getAuthHeaders } from "@/lib/getAuthToken";
 import Link from "next/link";
 
 export default function SessionCreator() {
@@ -19,10 +20,7 @@ export default function SessionCreator() {
     try {
       const res = await fetch("/api/group/create", {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${session?.access_token}`,
-        },
+        headers: await getAuthHeaders(),
       });
 
       const data = await res.json();

--- a/components/group/SwipeCard.tsx
+++ b/components/group/SwipeCard.tsx
@@ -4,6 +4,7 @@ import type { DeckFilm } from "@/lib/types";
 import { moodMap } from "@/lib/moodMap";
 import { genreMap } from "@/lib/genres";
 import { useMediaQuery } from "@/lib/useMediaQuery";
+import { ACCENT_VARS } from "@/lib/constants";
 
 interface SwipeCardProps {
   film: DeckFilm;
@@ -16,16 +17,6 @@ interface SwipeCardProps {
   onPointerMove: (e: React.PointerEvent) => void;
   onPointerUp: () => void;
 }
-
-// Accent color → CSS variable triplet
-const accentVars: Record<string, { color: string; bg: string; border: string }> = {
-  gold:   { color: "var(--gold)",   bg: "var(--gold-soft)",   border: "rgba(196,163,90,0.25)" },
-  blue:   { color: "var(--blue)",   bg: "var(--blue-soft)",   border: "rgba(91,143,212,0.25)" },
-  rose:   { color: "var(--rose)",   bg: "var(--rose-soft)",   border: "rgba(196,107,124,0.25)" },
-  violet: { color: "var(--violet)", bg: "var(--violet-soft)", border: "rgba(139,108,196,0.25)" },
-  teal:   { color: "var(--teal)",   bg: "var(--teal-soft)",   border: "rgba(90,170,143,0.25)" },
-  ember:  { color: "var(--ember)",  bg: "var(--ember-soft)",  border: "rgba(212,122,74,0.25)" },
-};
 
 // Exit transforms keyed by direction
 const EXIT_TRANSFORMS: Record<string, string> = {
@@ -264,7 +255,7 @@ export default function SwipeCard({
         {moodTags.length > 0 && (
           <div style={{ display: "flex", gap: "5px", flexWrap: "wrap", marginBottom: "6px" }}>
             {moodTags.map((tag) => {
-              const vars = accentVars[tag.accent] ?? accentVars.gold;
+              const vars = ACCENT_VARS[tag.accent as keyof typeof ACCENT_VARS] ?? ACCENT_VARS.gold;
               return (
                 <span
                   key={tag.label}

--- a/components/group/SwipeDeck.tsx
+++ b/components/group/SwipeDeck.tsx
@@ -81,7 +81,7 @@ export default function SwipeDeck({
   const votingRef = useRef(false);
 
   useEffect(() => {
-    setCurrentIndex(startIndex);
+    setCurrentIndex((prev) => Math.max(prev, startIndex));
   }, [startIndex]);
 
   const triggerVote = useCallback(

--- a/components/group/TopPickCard.tsx
+++ b/components/group/TopPickCard.tsx
@@ -5,20 +5,8 @@ import type { MatchResult, Provider } from "@/lib/types";
 import { moodMap } from "@/lib/moodMap";
 import { genreMap } from "@/lib/genres";
 import { useMediaQuery } from "@/lib/useMediaQuery";
+import { ACCENT_VARS } from "@/lib/constants";
 import VoteBreakdown from "./VoteBreakdown";
-
-// Same accent palette used by SwipeCard — keeps mood chip colors consistent
-const accentVars: Record<
-  string,
-  { color: string; bg: string; border: string }
-> = {
-  gold: { color: "var(--gold)", bg: "var(--gold-soft)", border: "rgba(196,163,90,0.25)" },
-  blue: { color: "var(--blue)", bg: "var(--blue-soft)", border: "rgba(91,143,212,0.25)" },
-  rose: { color: "var(--rose)", bg: "var(--rose-soft)", border: "rgba(196,107,124,0.25)" },
-  violet: { color: "var(--violet)", bg: "var(--violet-soft)", border: "rgba(139,108,196,0.25)" },
-  teal: { color: "var(--teal)", bg: "var(--teal-soft)", border: "rgba(90,170,143,0.25)" },
-  ember: { color: "var(--ember)", bg: "var(--ember-soft)", border: "rgba(212,122,74,0.25)" },
-};
 
 interface TopPickCardProps {
   result: MatchResult;
@@ -188,7 +176,7 @@ export default function TopPickCard({
           {(moodTags.length > 0 || genres.length > 0) && (
             <div style={{ display: "flex", gap: "5px", flexWrap: "wrap" }}>
               {moodTags.map((tag) => {
-                const vars = accentVars[tag.accent] ?? accentVars.gold;
+                const vars = ACCENT_VARS[tag.accent as keyof typeof ACCENT_VARS] ?? ACCENT_VARS.gold;
                 return (
                   <span
                     key={tag.label}

--- a/components/group/VoteBreakdown.tsx
+++ b/components/group/VoteBreakdown.tsx
@@ -1,16 +1,7 @@
 "use client";
 
 import type { SwipeVote } from "@/lib/types";
-
-// Same avatar palette as the swipe page so participant identity stays consistent
-// across the flow (lobby → mood → swipe → results)
-const AVATAR_COLORS = [
-  { bg: "var(--gold)", text: "#0a0a0c" },
-  { bg: "var(--teal)", text: "#0a0a0c" },
-  { bg: "var(--rose)", text: "#fff" },
-  { bg: "var(--blue)", text: "#fff" },
-  { bg: "var(--violet)", text: "#fff" },
-];
+import { AVATAR_COLORS } from "@/lib/constants";
 
 // Vote → color token. Kept as CSS vars so both themes resolve correctly.
 const VOTE_COLORS: Record<SwipeVote, string> = {

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,28 @@
+import type { AccentColor } from "./types";
+
+/**
+ * Consistent avatar colors for participants across all group pages.
+ * Index by participant position so the same person
+ * gets the same color in lobby, swipe, and results.
+ */
+export const AVATAR_COLORS: { bg: string; text: string }[] = [
+  { bg: "var(--teal)", text: "#0a0a0c" },
+  { bg: "var(--gold)", text: "#0a0a0c" },
+  { bg: "var(--blue)", text: "#fff" },
+  { bg: "var(--violet)", text: "#fff" },
+  { bg: "var(--rose)", text: "#fff" },
+  { bg: "var(--ember)", text: "#0a0a0c" },
+];
+
+/** Mood accent color → CSS variable triplets for mood/genre chips on cards */
+export const ACCENT_VARS: Record<
+  AccentColor,
+  { color: string; bg: string; border: string }
+> = {
+  gold: { color: "var(--gold)", bg: "var(--gold-soft)", border: "rgba(196,163,90,0.25)" },
+  blue: { color: "var(--blue)", bg: "var(--blue-soft)", border: "rgba(91,143,212,0.25)" },
+  rose: { color: "var(--rose)", bg: "var(--rose-soft)", border: "rgba(196,107,124,0.25)" },
+  violet: { color: "var(--violet)", bg: "var(--violet-soft)", border: "rgba(139,108,196,0.25)" },
+  teal: { color: "var(--teal)", bg: "var(--teal-soft)", border: "rgba(90,170,143,0.25)" },
+  ember: { color: "var(--ember)", bg: "var(--ember-soft)", border: "rgba(212,122,74,0.25)" },
+};

--- a/lib/deck.ts
+++ b/lib/deck.ts
@@ -1,0 +1,160 @@
+import { buildTMDBParams } from "@/lib/moodMap";
+import type { DeckFilm } from "@/lib/types";
+
+const DECK_SIZE = 15;
+
+interface TMDBDiscoverResult {
+  id: number;
+  title: string;
+  poster_path: string | null;
+  release_date: string;
+  vote_average: number;
+  overview: string;
+  genre_ids: number[];
+}
+
+/**
+ * Aggregate all participants' moods with weighted frequency,
+ * fetch films from TMDB, and build a balanced deck.
+ * Each film is tagged with genre_ids and the mood(s) it was sourced from.
+ */
+export async function buildSharedDeck(
+  participants: { mood_selections: string[] | null }[],
+): Promise<DeckFilm[]> {
+  const apiKey = process.env.TMDB_API_KEY;
+  if (!apiKey) throw new Error("TMDB API key not configured");
+
+  // Count mood frequency across all participants
+  const moodCounts: Record<string, number> = {};
+  for (const p of participants) {
+    if (!p.mood_selections) continue;
+    for (const mood of p.mood_selections) {
+      moodCounts[mood] = (moodCounts[mood] || 0) + 1;
+    }
+  }
+
+  const totalWeight = Object.values(moodCounts).reduce((a, b) => a + b, 0);
+  if (totalWeight === 0) return [];
+
+  // Allocate film slots proportionally
+  const allocations: { mood: string; count: number }[] = [];
+  let allocated = 0;
+
+  const sortedMoods = Object.entries(moodCounts).sort((a, b) => b[1] - a[1]);
+
+  for (const [mood, weight] of sortedMoods) {
+    const share = Math.max(1, Math.round((weight / totalWeight) * DECK_SIZE));
+    allocations.push({ mood, count: share });
+    allocated += share;
+  }
+
+  // Adjust to hit exactly DECK_SIZE films, trimming from the least popular moods first
+  while (allocated > DECK_SIZE) {
+    let trimmed = false;
+    for (let i = allocations.length - 1; i >= 0; i--) {
+      if (allocations[i].count > 1) {
+        allocations[i].count--;
+        allocated--;
+        trimmed = true;
+        break;
+      }
+    }
+    // Every mood is at count=1, drop the least popular ones
+    if (!trimmed) {
+      allocations.pop();
+      allocated--;
+    }
+  }
+  while (allocated < DECK_SIZE) {
+    allocations[0].count++;
+    allocated++;
+  }
+
+  // Fetch TMDB results for each unique mood in parallel
+  const fetchResults = allocations.map(async ({ mood, count }) => {
+    const moodParams = buildTMDBParams(mood);
+    const url = new URL("https://api.themoviedb.org/3/discover/movie");
+    url.searchParams.set("api_key", apiKey);
+    url.searchParams.set("language", "en-US");
+    url.searchParams.set("page", "1");
+
+    for (const [k, v] of Object.entries(moodParams)) {
+      url.searchParams.set(k, v);
+    }
+
+    const res = await fetch(url.toString());
+    const data = await res.json();
+    const results: DeckFilm[] = (data.results ?? []).map(
+      (r: TMDBDiscoverResult) => ({
+        id: r.id,
+        title: r.title,
+        poster_path: r.poster_path,
+        release_date: r.release_date,
+        vote_average: r.vote_average,
+        overview: r.overview,
+        genre_ids: r.genre_ids ?? [],
+        mood_keys: [mood],
+      }),
+    );
+
+    return { mood, count, results };
+  });
+
+  const moodResults = await Promise.all(fetchResults);
+
+  // Build deck: pick films per mood allocation, dedup across moods.
+  // If a film appears under multiple moods, merge the mood_keys.
+  const seen = new Map<number, DeckFilm>();
+  const deck: DeckFilm[] = [];
+
+  for (const { mood, count, results } of moodResults) {
+    let picked = 0;
+    for (const film of results) {
+      if (picked >= count) break;
+      const existing = seen.get(film.id);
+      if (existing) {
+        if (!existing.mood_keys.includes(mood)) {
+          existing.mood_keys.push(mood);
+        }
+        continue;
+      }
+      const deckFilm: DeckFilm = {
+        id: film.id,
+        title: film.title,
+        poster_path: film.poster_path,
+        release_date: film.release_date,
+        vote_average: film.vote_average,
+        overview: film.overview,
+        genre_ids: film.genre_ids,
+        mood_keys: [mood],
+      };
+      seen.set(film.id, deckFilm);
+      deck.push(deckFilm);
+      picked++;
+    }
+  }
+
+  // If any mood couldn't fill its allocation, backfill from others
+  if (deck.length < DECK_SIZE) {
+    for (const { mood, results } of moodResults) {
+      for (const film of results) {
+        if (deck.length >= DECK_SIZE) break;
+        if (seen.has(film.id)) continue;
+        const deckFilm: DeckFilm = {
+          id: film.id,
+          title: film.title,
+          poster_path: film.poster_path,
+          release_date: film.release_date,
+          vote_average: film.vote_average,
+          overview: film.overview,
+          genre_ids: film.genre_ids,
+          mood_keys: [mood],
+        };
+        seen.set(film.id, deckFilm);
+        deck.push(deckFilm);
+      }
+    }
+  }
+
+  return deck;
+}

--- a/lib/getAuthToken.ts
+++ b/lib/getAuthToken.ts
@@ -1,0 +1,26 @@
+import { supabase } from "@/lib/supabase";
+
+/**
+ * Get a fresh access token directly from the Supabase client.
+ * Avoids stale-token issues where React state holds an expired JWT
+ * while Supabase has already auto-refreshed internally.
+ */
+async function getAuthToken(): Promise<string | null> {
+  const { data: { session } } = await supabase.auth.getSession();
+  return session?.access_token ?? null;
+}
+
+/**
+ * Build request headers with a fresh auth token.
+ * Includes Content-Type and Authorization (if logged in).
+ */
+export async function getAuthHeaders(): Promise<Record<string, string>> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  const token = await getAuthToken();
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return headers;
+}

--- a/lib/group-api.ts
+++ b/lib/group-api.ts
@@ -1,0 +1,114 @@
+import { NextResponse } from "next/server";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { User } from "@supabase/supabase-js";
+import { isSessionExpired } from "@/lib/group";
+
+type ResolveResult<T> =
+  | { session: T; error: null }
+  | { session: null; error: NextResponse };
+
+type ParticipantResult<T> =
+  | { participant: T; error: null }
+  | { participant: null; error: NextResponse };
+
+/**
+ * Validate the 6-char code, fetch the session, and check expiry.
+ * Returns the session row or an error response ready to return.
+ */
+export async function resolveSession<
+  T extends { created_at: string } = { created_at: string },
+>(
+  supabase: SupabaseClient,
+  code: string,
+  selectFields = "id, status, created_at",
+): Promise<ResolveResult<T>> {
+  if (!code || code.length !== 6) {
+    return {
+      session: null,
+      error: NextResponse.json(
+        { error: "Invalid session code" },
+        { status: 400 },
+      ),
+    };
+  }
+
+  const upperCode = code.toUpperCase();
+
+  const { data: session, error: sessionError } = await supabase
+    .from("sessions")
+    .select(selectFields)
+    .eq("code", upperCode)
+    .single();
+
+  if (sessionError || !session) {
+    return {
+      session: null,
+      error: NextResponse.json(
+        { error: "Session not found" },
+        { status: 404 },
+      ),
+    };
+  }
+
+  if (isSessionExpired((session as unknown as { created_at: string }).created_at)) {
+    return {
+      session: null,
+      error: NextResponse.json(
+        { error: "Session expired" },
+        { status: 410 },
+      ),
+    };
+  }
+
+  return { session: session as unknown as T, error: null };
+}
+
+/**
+ * Find a participant by user_id (authenticated) or participantId (guest).
+ * Returns the participant row or an error response.
+ */
+export async function resolveParticipant<
+  T extends { id: string } = { id: string },
+>(
+  supabase: SupabaseClient,
+  sessionId: string,
+  user: User | null,
+  participantId: string | null,
+  selectFields = "id",
+): Promise<ParticipantResult<T>> {
+  if (!user && !participantId) {
+    return {
+      participant: null,
+      error: NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401 },
+      ),
+    };
+  }
+
+  const query = supabase
+    .from("session_participants")
+    .select(selectFields)
+    .eq("session_id", sessionId);
+
+  if (user) {
+    query.eq("user_id", user.id);
+  } else {
+    query.eq("id", participantId!);
+  }
+
+  const { data: participant, error: participantError } =
+    await query.single();
+
+  if (participantError || !participant) {
+    return {
+      participant: null,
+      error: NextResponse.json(
+        { error: "You are not in this session" },
+        { status: 403 },
+      ),
+    };
+  }
+
+  return { participant: participant as unknown as T, error: null };
+}

--- a/lib/group.ts
+++ b/lib/group.ts
@@ -45,4 +45,18 @@ function isSessionExpired(createdAt: string): boolean {
   return now - created > SESSION_EXPIRY_HOURS * 60 * 60 * 1000;
 }
 
-export { MAX_PARTICIPANTS, SESSION_EXPIRY_HOURS, isSessionExpired };
+/** Classify a film into a tier based on vote breakdown */
+function classifyTier(
+  yesCount: number,
+  noCount: number,
+  participantCount: number,
+): "perfect" | "strong" | "miss" {
+  if (participantCount === 0) return "miss";
+  if (yesCount === participantCount) return "perfect";
+  if (noCount === 0 && yesCount >= Math.ceil(participantCount / 2)) {
+    return "strong";
+  }
+  return "miss";
+}
+
+export { MAX_PARTICIPANTS, SESSION_EXPIRY_HOURS, isSessionExpired, classifyTier };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -79,7 +79,7 @@ export interface GroupSession {
   code: string;
   host_id: string;
   status: SessionStatus;
-  movie_deck: Film[] | null;
+  movie_deck: DeckFilm[] | null;
   created_at: string;
 }
 

--- a/lib/useGroupRealtime.ts
+++ b/lib/useGroupRealtime.ts
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { supabase } from "@/lib/supabase";
+
+interface UseGroupRealtimeOptions {
+  /** Supabase session ID — channels only subscribe once this is set */
+  sessionId: string | null;
+  /** Prefix for channel names to avoid collisions (e.g. "lobby", "mood") */
+  channelPrefix: string;
+  /** Called on every Realtime event + polling tick */
+  onUpdate: () => void;
+  /** Called when the session row is deleted (e.g. host disbands) */
+  onDelete?: () => void;
+  /** Set to true to pause polling (e.g. during loading or transition) */
+  paused?: boolean;
+}
+
+/**
+ * Sets up Supabase Realtime subscriptions on session_participants + sessions
+ * tables, plus a 2s polling fallback. Cleans up on unmount.
+ */
+export function useGroupRealtime({
+  sessionId,
+  channelPrefix,
+  onUpdate,
+  onDelete,
+  paused = false,
+}: UseGroupRealtimeOptions) {
+  // Always hold the latest callbacks without re-subscribing
+  const onUpdateRef = useRef(onUpdate);
+  const onDeleteRef = useRef(onDelete);
+  useEffect(() => {
+    onUpdateRef.current = onUpdate;
+    onDeleteRef.current = onDelete;
+  });
+
+  // Realtime subscriptions
+  useEffect(() => {
+    if (!sessionId) return;
+
+    const participantsChannel = supabase
+      .channel(`${channelPrefix}-participants-${sessionId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "session_participants",
+          filter: `session_id=eq.${sessionId}`,
+        },
+        () => {
+          onUpdateRef.current();
+        },
+      )
+      .subscribe();
+
+    const sessionChannel = supabase
+      .channel(`${channelPrefix}-session-${sessionId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "sessions",
+          filter: `id=eq.${sessionId}`,
+        },
+        (payload) => {
+          if (payload.eventType === "DELETE") {
+            onDeleteRef.current?.();
+            return;
+          }
+          onUpdateRef.current();
+        },
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(participantsChannel);
+      supabase.removeChannel(sessionChannel);
+    };
+  }, [sessionId, channelPrefix]);
+
+  // Polling fallback every 2s
+  useEffect(() => {
+    if (paused) return;
+    const interval = setInterval(() => {
+      onUpdateRef.current();
+    }, 2000);
+    return () => clearInterval(interval);
+  }, [paused]);
+}

--- a/lib/useParticipantId.ts
+++ b/lib/useParticipantId.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+/**
+ * Reads the guest participantId from localStorage.
+ * Returns { participantId, ready } — ready is false until
+ * localStorage has been checked, preventing premature API calls.
+ */
+export function useParticipantId() {
+  const [state, setState] = useState<{
+    participantId: string | null;
+    ready: boolean;
+  }>({ participantId: null, ready: false });
+
+  useEffect(() => {
+    const stored = localStorage.getItem("participantId");
+    setState({ participantId: stored, ready: true });
+  }, []);
+
+  return state;
+}


### PR DESCRIPTION
## Summary

This pull request cleans up the group session code and fixes a few issues that were causing inconsistent behavior.

The main goal was to reduce duplication, make the flow more stable, and move shared logic into one place so it’s easier to maintain going forward.

Key improvements:
- Reduced repeated session and participant logic by moving it into shared helpers
- Centralized realtime updates, polling, and local state handling into reusable hooks
- Fixed authentication issues that caused random errors after being logged in for a while
- Resolved swipe issues where cards could jump back or the “done” screen would not appear
- Cleaned up and unified shared constants (colors, styling)
- Moved deck-building logic into a single place
- Fixed an issue where the movie deck could break if too many moods were selected
- Removed unused code and updated internal documentation

---

## Test Plan

- [x] Logged-in user: create session → disband → create another — no auth errors
- [x] Desktop: swipe all cards at normal pace — done screen appears correctly
- [x] Desktop: swipe quickly — no cards jump back, flow stays stable
- [x] Mobile (guest): join session and swipe all cards — no blank or broken screens
- [x] Both participants finish swiping — results load correctly for both
- [x] Results page: top pick and vote breakdown display correctly
- [x] Lobby: join/leave/ready actions still work as expected
- [x] Mood page: submitting moods progresses correctly into swipe phase
- [x] Guest flow: join → mood → swipe → results works end-to-end without errors
- [x] Light and dark themes render correctly across all group pages