### PR TITLE
test: add end-to-end tests with Playwright

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Copy to .env.local
+
+# --- Supabase --- (project settings → API)
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your_anon_public_key
+SUPABASE_SERVICE_ROLE_KEY=your_service_role_key
+
+# --- TMDB --- (https://www.themoviedb.org/settings/api)
+TMDB_API_KEY=your_tmdb_api_key
+
+# --- NextAuth --- (required as dependency; secret: `openssl rand -base64 32`)
+NEXTAUTH_SECRET=your_generated_secret
+NEXTAUTH_URL=http://localhost:3000

--- a/.env.test.example
+++ b/.env.test.example
@@ -1,0 +1,6 @@
+# Copy to .env.test.local (gitignored). Dedicated Supabase user for Playwright E2E.
+# Provision with: npm run seed:e2e-user
+
+E2E_USER_EMAIL=e2e+test@filmood.app
+# Single quotes prevent dotenv from expanding `$` in the password.
+E2E_USER_PASSWORD='change-me-to-something-strong'

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 
 # testing
 /coverage
+/playwright-report
+/test-results
+/playwright/.cache
 
 # next.js
 /.next/

--- a/app/__tests__/login.test.tsx
+++ b/app/__tests__/login.test.tsx
@@ -61,7 +61,9 @@ async function fillLoginForm(
 ) {
   const user = userEvent.setup();
   await user.type(screen.getByLabelText(/email address/i), email);
-  await user.type(screen.getByLabelText(/password/i), password);
+  // Anchor the regex — the redesigned page has a "Show password" toggle
+  // button whose aria-label also matches /password/i.
+  await user.type(screen.getByLabelText(/^password$/i), password);
 }
 
 beforeEach(() => {
@@ -80,7 +82,7 @@ describe("LoginPage", () => {
   it("renders the email and password fields", () => {
     render(<LoginPage />);
     expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^password$/i)).toBeInTheDocument();
   });
 
   it("renders the submit button with initial text", () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -24,10 +25,12 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@vitest/ui": "^4.1.3",
+        "dotenv": "^17.4.1",
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
         "jsdom": "^27.0.1",
         "tailwindcss": "^4",
+        "tsx": "^4.21.0",
         "typescript": "^5",
         "vitest": "^4.1.3"
       }
@@ -527,6 +530,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1463,6 +1908,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -3893,6 +4354,19 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/dotenv": {
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
+      "integrity": "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -4132,6 +4606,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/escalade": {
@@ -6777,6 +7293,53 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -7887,6 +8450,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,11 @@
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:debug": "playwright test --debug",
+    "seed:e2e-user": "tsx scripts/seed-e2e-user.ts"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.99.1",
@@ -20,6 +24,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
@@ -28,10 +33,12 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitest/ui": "^4.1.3",
+    "dotenv": "^17.4.1",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "jsdom": "^27.0.1",
     "tailwindcss": "^4",
+    "tsx": "^4.21.0",
     "typescript": "^5",
     "vitest": "^4.1.3"
   }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,51 @@
+import { defineConfig, devices } from "@playwright/test";
+import { config as loadEnv } from "dotenv";
+import path from "path";
+
+// Load E2E credentials from untracked file.
+loadEnv({ path: path.resolve(__dirname, ".env.test.local") });
+
+const isCI = !!process.env.CI;
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  // Vitest is scoped to lib/__tests__ and app/__tests__, so no overlap.
+  testMatch: "**/*.test.ts",
+  // Extra headroom for slow Next 16 dev cold compiles.
+  expect: { timeout: 7_000 },
+  timeout: 45_000,
+  fullyParallel: true,
+  forbidOnly: isCI,
+  retries: isCI ? 2 : 0,
+  workers: isCI ? 1 : undefined,
+  // HTML report enables `npx playwright show-report` after any local run.
+  reporter: [["list"], ["html", { open: "never" }]],
+
+  use: {
+    baseURL: "http://localhost:3000",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+
+  projects: [
+    {
+      name: "chromium-desktop",
+      testIgnore: "**/mobile.test.ts",
+      use: { ...devices["Desktop Chrome"], viewport: { width: 1280, height: 800 } },
+    },
+    {
+      name: "chromium-mobile",
+      testMatch: "**/mobile.test.ts",
+      use: { ...devices["Pixel 5"] },
+    },
+  ],
+
+  // Auto-boot `next dev`; reuse existing server on 3000 locally.
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:3000",
+    reuseExistingServer: !isCI,
+    timeout: 120_000,
+  },
+});

--- a/scripts/seed-e2e-user.ts
+++ b/scripts/seed-e2e-user.ts
@@ -1,0 +1,76 @@
+/**
+ * Idempotent: provisions the E2E Supabase user for tests/e2e/.
+ * Reads admin creds from .env/.env.local, test creds from .env.test.local.
+ * Run: npm run seed:e2e-user
+ */
+
+import { createClient } from "@supabase/supabase-js";
+import { config as loadEnv } from "dotenv";
+import path from "path";
+
+const repoRoot = path.resolve(__dirname, "..");
+
+// Admin creds first, test creds layered on top.
+loadEnv({ path: path.join(repoRoot, ".env") });
+loadEnv({ path: path.join(repoRoot, ".env.local"), override: false });
+loadEnv({ path: path.join(repoRoot, ".env.test.local"), override: false });
+
+function must(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`Missing ${name}. Aborting.`);
+    process.exit(1);
+  }
+  return value;
+}
+
+async function main() {
+  const supabaseUrl = must("NEXT_PUBLIC_SUPABASE_URL");
+  const serviceKey = must("SUPABASE_SERVICE_ROLE_KEY");
+  const email = must("E2E_USER_EMAIL");
+  const password = must("E2E_USER_PASSWORD");
+
+  const admin = createClient(supabaseUrl, serviceKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  // First page only — switch to filter API if users ever exceed 200.
+  const { data: list, error: listErr } = await admin.auth.admin.listUsers({
+    page: 1,
+    perPage: 200,
+  });
+  if (listErr) {
+    console.error("Failed to list users:", listErr.message);
+    process.exit(1);
+  }
+
+  const existing = list.users.find(
+    (u) => u.email?.toLowerCase() === email.toLowerCase(),
+  );
+
+  if (existing) {
+    console.log(`E2E user already exists: ${email} (id: ${existing.id})`);
+    console.log("Nothing to do.");
+    return;
+  }
+
+  const { data: created, error: createErr } = await admin.auth.admin.createUser({
+    email,
+    password,
+    email_confirm: true,
+    user_metadata: { name: "Filmood E2E", seeded: true },
+  });
+
+  if (createErr) {
+    console.error("Failed to create E2E user:", createErr.message);
+    process.exit(1);
+  }
+
+  console.log(`Created E2E user: ${email} (id: ${created.user?.id})`);
+  console.log("Auto-confirmed email — tests can log in immediately.");
+}
+
+main().catch((err) => {
+  console.error("Unexpected error:", err);
+  process.exit(1);
+});

--- a/tests/e2e/auth.test.ts
+++ b/tests/e2e/auth.test.ts
@@ -1,0 +1,59 @@
+import { test, expect } from "@playwright/test";
+
+// Client-side zod validation + one real Supabase hit for "bad credentials". No TMDB mocks needed.
+
+test.describe("Auth forms", () => {
+  test("signup form shows zod errors when submitted empty", async ({
+    page,
+  }) => {
+    await page.goto("/signup");
+    await page.getByRole("button", { name: /^sign up$/i }).click();
+
+    // Errors sourced from signupSchema in lib/validations.ts.
+    await expect(
+      page.getByText(/name must be at least 3 characters/i),
+    ).toBeVisible();
+    await expect(page.getByText(/email is required/i)).toBeVisible();
+    await expect(
+      page.getByText(/password must be at least 6 characters/i),
+    ).toBeVisible();
+  });
+
+  test("signup form flags an invalid email format", async ({ page }) => {
+    await page.goto("/signup");
+
+    // Disable native email validation so zod's error can surface instead.
+    await page.locator("form").evaluate((f) => {
+      (f as HTMLFormElement).noValidate = true;
+    });
+
+    // Fill other fields so only the email error surfaces.
+    await page.getByLabel(/full name/i).fill("Test User");
+    await page.getByLabel(/email address/i).fill("not-an-email");
+    // ^password$ anchors past "Confirm password".
+    await page.getByLabel(/^password$/i).fill("secret123");
+    await page.getByLabel(/confirm password/i).fill("secret123");
+
+    await page.getByRole("button", { name: /^sign up$/i }).click();
+
+    await expect(page.getByText(/please enter a valid email/i)).toBeVisible();
+  });
+
+  test("login form shows Supabase error on bad credentials", async ({
+    page,
+  }) => {
+    await page.goto("/login");
+
+    // Fake account — Supabase returns 400 "Invalid login credentials".
+    await page
+      .getByLabel(/email address/i)
+      .fill("nobody-e2e-fake@filmood.test");
+    await page.getByLabel(/^password$/i).fill("definitely-wrong-123");
+
+    await page.getByRole("button", { name: /^log in$/i }).click();
+
+    await expect(
+      page.getByText(/invalid login credentials/i),
+    ).toBeVisible();
+  });
+});

--- a/tests/e2e/fixtures/auth.ts
+++ b/tests/e2e/fixtures/auth.ts
@@ -1,0 +1,28 @@
+import type { Page } from "@playwright/test";
+
+/** Logs in the E2E user. Creds loaded from .env.test.local via playwright.config.ts. */
+export async function loginAsTestUser(page: Page) {
+  const email = process.env.E2E_USER_EMAIL;
+  const password = process.env.E2E_USER_PASSWORD;
+
+  if (!email || !password) {
+    throw new Error(
+      "Missing E2E_USER_EMAIL / E2E_USER_PASSWORD. Add them to .env.test.local at the repo root.",
+    );
+  }
+
+  await page.goto("/login");
+  await page.getByLabel(/email address/i).fill(email);
+  await page.getByLabel(/^password$/i).fill(password);
+  await page.getByRole("button", { name: /^log in$/i }).click();
+
+  // Match "not /login" instead of "/" to tolerate trailing-slash/query differences.
+  await page.waitForURL((url) => !url.pathname.startsWith("/login"), {
+    timeout: 10_000,
+  });
+
+  // Wait for "Sign out" — proxy for AuthProvider's async INITIAL_SESSION propagating.
+  await page
+    .getByRole("button", { name: /sign out/i })
+    .waitFor({ state: "visible", timeout: 10_000 });
+}

--- a/tests/e2e/fixtures/tmdb.ts
+++ b/tests/e2e/fixtures/tmdb.ts
@@ -1,0 +1,175 @@
+import type { Page } from "@playwright/test";
+
+// Deterministic fixtures for E2E — mockTmdb() serves these instead of real TMDB.
+// IDs use 9900xx range so they're obvious in logs.
+
+export const fakeFilms = [
+  {
+    id: 990001,
+    title: "Midnight Harvest",
+    poster_path: "/fake-poster-1.jpg",
+    backdrop_path: "/fake-backdrop-1.jpg",
+    release_date: "2024-09-12",
+    vote_average: 8.2,
+    overview: "A retired chef chases an old recipe across three countries.",
+    genre_ids: [18, 10749],
+  },
+  {
+    id: 990002,
+    title: "The Quiet Algorithm",
+    poster_path: "/fake-poster-2.jpg",
+    backdrop_path: "/fake-backdrop-2.jpg",
+    release_date: "2023-04-20",
+    vote_average: 7.6,
+    overview: "A lonely coder teaches a language model to grieve.",
+    genre_ids: [18, 878],
+  },
+  {
+    id: 990003,
+    title: "Paper Lanterns",
+    poster_path: "/fake-poster-3.jpg",
+    backdrop_path: "/fake-backdrop-3.jpg",
+    release_date: "2022-11-03",
+    vote_average: 7.1,
+    overview: "Two siblings reopen their grandmother's failing noodle shop.",
+    genre_ids: [35, 10751],
+  },
+  {
+    id: 990004,
+    title: "North Sea Static",
+    poster_path: "/fake-poster-4.jpg",
+    backdrop_path: "/fake-backdrop-4.jpg",
+    release_date: "2024-02-17",
+    vote_average: 6.9,
+    overview: "A lighthouse keeper picks up a signal that shouldn't exist.",
+    genre_ids: [53, 9648],
+  },
+  {
+    id: 990005,
+    title: "Weekend Physics",
+    poster_path: "/fake-poster-5.jpg",
+    backdrop_path: "/fake-backdrop-5.jpg",
+    release_date: "2023-07-28",
+    vote_average: 7.4,
+    overview: "Three friends try to recreate a famous experiment in a garage.",
+    genre_ids: [35, 18],
+  },
+];
+
+export const fakeFilmDetail = {
+  id: 990001,
+  title: "Midnight Harvest",
+  overview: "A retired chef chases an old recipe across three countries.",
+  poster_path: "/fake-poster-1.jpg",
+  backdrop_path: "/fake-backdrop-1.jpg",
+  release_date: "2024-09-12",
+  runtime: 118,
+  vote_average: 8.2,
+  genres: [
+    { id: 18, name: "Drama" },
+    { id: 10749, name: "Romance" },
+  ],
+  credits: {
+    cast: [
+      {
+        id: 1,
+        name: "Alma Berger",
+        character: "Mira",
+        profile_path: "/fake-cast-1.jpg",
+      },
+      {
+        id: 2,
+        name: "Tomas Reyes",
+        character: "Owen",
+        profile_path: "/fake-cast-2.jpg",
+      },
+    ],
+  },
+};
+
+export const fakeProviders = [
+  { provider_id: 8, provider_name: "Netflix", logo_path: "/fake-netflix.jpg" },
+];
+
+export const fakeTrailer = {
+  key: "dQw4w9WgXcQ",
+  name: "Official Trailer",
+  site: "YouTube",
+  type: "Trailer",
+};
+
+/**
+ * Intercepts movie API routes with fixtures. Call before `page.goto()`.
+ * Uses regex (not globs) to prevent `**\/api/movies/*` from swallowing sub-routes.
+ */
+export async function mockTmdb(page: Page) {
+  await page.route(/\/api\/movies\/trending(\?.*)?$/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        films: fakeFilms.slice(0, 4).map((f) => ({
+          id: f.id,
+          title: f.title,
+          genre_ids: f.genre_ids,
+          backdrop_path: f.backdrop_path,
+        })),
+      }),
+    }),
+  );
+
+  await page.route(/\/api\/movies\/discover(\?.*)?$/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        mood: "laugh",
+        moods: ["Laugh until it hurts"],
+        films: fakeFilms,
+        total: fakeFilms.length,
+      }),
+    }),
+  );
+
+  await page.route(/\/api\/movies\/search(\?.*)?$/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      // Must match real shape `{ films }` — SearchBox reads `data.films ?? []`.
+      body: JSON.stringify({ films: fakeFilms }),
+    }),
+  );
+
+  await page.route(/\/api\/movies\/browse(\?.*)?$/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ films: fakeFilms, page: 1, totalPages: 1 }),
+    }),
+  );
+
+  await page.route(/\/api\/movies\/\d+\/providers$/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ providers: fakeProviders }),
+    }),
+  );
+
+  await page.route(/\/api\/movies\/\d+\/trailer$/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(fakeTrailer),
+    }),
+  );
+
+  // Film detail — `$` anchor keeps /providers and /trailer from matching here.
+  await page.route(/\/api\/movies\/\d+$/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(fakeFilmDetail),
+    }),
+  );
+}

--- a/tests/e2e/group-session.test.ts
+++ b/tests/e2e/group-session.test.ts
@@ -1,0 +1,62 @@
+import { test, expect } from "@playwright/test";
+import { loginAsTestUser } from "./fixtures/auth";
+import { mockTmdb } from "./fixtures/tmdb";
+
+// Single-user smoke test: log in → create → verify lobby → disband.
+// Realtime swipe matching is covered in lib/__tests__/group-gameplay.test.ts.
+// TMDB is stubbed because the dashboard and lobby hit /api/movies on load.
+
+test.describe("Group session — create and disband", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockTmdb(page);
+  });
+
+  test("logged-in host can create a session and disband it", async ({
+    page,
+  }) => {
+    await loginAsTestUser(page);
+
+    await page.goto("/group");
+
+    // Header confirms Suspense resolved.
+    await expect(
+      page.getByRole("heading", { level: 1, name: /group session/i }),
+    ).toBeVisible();
+
+    // Wait for CTA copy to ensure SessionCreator is in logged-in state.
+    // Two "Create session" buttons exist (tab toggle + CTA); nth(1) = CTA.
+    await expect(page.getByText(/start a private room/i)).toBeVisible();
+
+    const creatorCta = page
+      .getByRole("button", { name: /^create session$/i })
+      .nth(1);
+    await expect(creatorCta).toBeEnabled();
+    await creatorCta.click();
+
+    // Wait for the create POST to return.
+    await page.waitForResponse(
+      (res) =>
+        res.url().includes("/api/group/create") && res.request().method() === "POST",
+      { timeout: 10_000 },
+    );
+
+    // SessionCreator pushes to /group/{6-char code} on success.
+    await page.waitForURL(/\/group\/[A-Z0-9]{6}$/i);
+
+    const code = new URL(page.url()).pathname.split("/").pop()!;
+    expect(code).toMatch(/^[A-Z0-9]{6}$/i);
+
+    // Code is rendered somewhere in the lobby via <InviteStrip />.
+    await expect(page.getByText(code).first()).toBeVisible();
+
+    // Host sees "Disband session" (guests see "Leave"). Click flips to a Yes/No confirm.
+    await page.getByRole("button", { name: /^disband session$/i }).click();
+    await page.getByRole("button", { name: /^yes$/i }).click();
+
+    // onDisbanded → router.replace("/group").
+    await page.waitForURL(/\/group(\?.*)?$/);
+    await expect(
+      page.getByRole("heading", { level: 1, name: /group session/i }),
+    ).toBeVisible();
+  });
+});

--- a/tests/e2e/guest-dashboard.test.ts
+++ b/tests/e2e/guest-dashboard.test.ts
@@ -1,0 +1,53 @@
+import { test, expect } from "@playwright/test";
+import { mockTmdb } from "./fixtures/tmdb";
+
+test.describe("Guest dashboard", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockTmdb(page);
+  });
+
+  test("home renders hero, the three dashboard boxes, and no page errors", async ({
+    page,
+  }) => {
+    // Catch real uncaught exceptions (not Next dev console noise).
+    const pageErrors: string[] = [];
+    page.on("pageerror", (err) => pageErrors.push(err.message));
+
+    await page.goto("/");
+
+    // Final word cycles — assert only on the static "Play your" prefix.
+    const heading = page.getByRole("heading", { level: 1 });
+    await expect(heading).toContainText(/play your/i);
+
+    // Dashboard boxes expose role="button" via aria-label.
+    await expect(
+      page.getByRole("button", { name: /pick your mood/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /discover together/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /find anything/i }),
+    ).toBeVisible();
+
+    expect(pageErrors).toEqual([]);
+  });
+
+  test("theme toggle flips data-theme between dark and light", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const html = page.locator("html");
+    await expect(html).toHaveAttribute("data-theme", "dark");
+
+    await page
+      .getByRole("button", { name: /switch to light theme/i })
+      .click();
+    await expect(html).toHaveAttribute("data-theme", "light");
+
+    await page.getByRole("button", { name: /switch to dark theme/i }).click();
+    await expect(html).toHaveAttribute("data-theme", "dark");
+  });
+
+});

--- a/tests/e2e/mobile.test.ts
+++ b/tests/e2e/mobile.test.ts
@@ -1,0 +1,34 @@
+import { test, expect } from "@playwright/test";
+import { mockTmdb } from "./fixtures/tmdb";
+
+// Mobile-only (chromium-mobile project, Pixel 5). Below 900px, DashboardShell
+// swaps inline panels for a BottomSheet dialog — this covers its open/close lifecycle.
+
+test.describe("Mobile — BottomSheet dashboard panel", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockTmdb(page);
+  });
+
+  test("tapping See all moods opens the bottom sheet and Close dismisses it", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    // MoodCards inside MoodBox stopPropagation, so use "See all moods"
+    // (calls onExpand directly) to reliably open the panel on mobile.
+    await page.getByRole("button", { name: /see all moods/i }).tap();
+
+    const sheet = page.getByRole("dialog", { name: /panel/i });
+    await expect(sheet).toBeVisible();
+
+    // Sanity check that the mood panel (not search/explore) is embedded.
+    await expect(sheet.getByText(/all moods/i)).toBeVisible();
+
+    // Close detection via body scroll lock: BottomSheet slides off-screen via
+    // transform, so toBeHidden() is unreliable. Body `overflow: hidden` is set
+    // on open and cleared on close — a direct readout of sheet state.
+    await sheet.getByRole("button", { name: /^close$/i }).tap();
+
+    await expect(page.locator("body")).not.toHaveCSS("overflow", "hidden");
+  });
+});

--- a/tests/e2e/mood-to-film.test.ts
+++ b/tests/e2e/mood-to-film.test.ts
@@ -1,0 +1,42 @@
+import { test, expect } from "@playwright/test";
+import { mockTmdb } from "./fixtures/tmdb";
+
+// Core user journey: dashboard → mood → results → film detail. TMDB fully stubbed.
+
+test.describe("Mood → results → film detail", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockTmdb(page);
+  });
+
+  test("guest can pick a mood and reach a film detail page", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    // Expand full MoodPanel — picking from the 2x2 preview would cause
+    // strict-mode duplicate matches with the expanded panel.
+    await page.getByRole("button", { name: /see all moods/i }).click();
+
+    // "A good cry" is only in the expanded panel, so no duplicate match.
+    await page.getByRole("button", { name: /a good cry/i }).click();
+
+    await page.getByRole("button", { name: /find films/i }).click();
+    await page.waitForURL(/\/results\?mood=/);
+
+    await expect(
+      page.getByRole("heading", { level: 1, name: /your matches/i }),
+    ).toBeVisible();
+
+    // "Midnight Harvest" is the highest-rated fixture — confirms data pipeline reached UI.
+    await expect(
+      page.getByRole("heading", { level: 2, name: /midnight harvest/i }),
+    ).toBeVisible();
+
+    // Assert href only — the /film/{id} page is an RSC that fetches server-side,
+    // which page.route() can't intercept, so a fake ID would 404 at real TMDB.
+    const href = await page
+      .getByRole("link", { name: /view details/i })
+      .getAttribute("href");
+    expect(href).toMatch(/^\/film\/\d+$/);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,11 +4,15 @@ import path from "path";
 export default defineConfig({
   test: {
     globals: true,
-    // Default to node; jsdom is opt-in per folder so existing lib tests stay fast
+    // Default node; opt into jsdom per-file via /** @vitest-environment jsdom */.
     environment: "node",
-    // Per-file environment is set via /** @vitest-environment jsdom */ docblocks.
-    // Existing lib/__tests__/*.test.ts files stay on the node default.
     setupFiles: ["./tests/setup.ts"],
+    // Excludes tests/e2e/ (Playwright specs use a different runner).
+    include: [
+      "lib/__tests__/**/*.test.{ts,tsx}",
+      "app/__tests__/**/*.test.{ts,tsx}",
+      "components/__tests__/**/*.test.{ts,tsx}",
+    ],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
# test: add end-to-end tests with Playwright


Set up end-to-end tests using Playwright for both desktop and mobile.

### Covers
- Full guest flow (home → mood → results → film details)
- Login and signup forms (validation + wrong credentials)
- Group session flow (create and end session as a logged-in host)
- Mobile bottom sheet open/close behavior

### Notes
- Movie data (TMDB) is mocked with fixed test data to keep tests stable
- Uses a dedicated test user stored in `.env.test.local`
- Includes a simple seed script to create the test user
- Test setup is separated to avoid conflicts with unit tests